### PR TITLE
Update message factory dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "php-http/message-factory": "^0.1"
+        "php-http/message-factory": "~0.2@dev"
     },
     "require-dev": {
         "zendframework/zend-diactoros": "^1.0",


### PR DESCRIPTION
When using both php-http/utils and php-http/discovery there is a conflict as utils depends on dev-master for message factory but dev-master of discovery depends on ^0.1.1