### PR TITLE
require puli cli to work out of the box

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     "require": {
         "php": "^5.4|7.*",
         "puli/composer-plugin": "~1.0.0-beta8",
-        "puli/discovery": "~1.0.0-beta8"
+        "puli/discovery": "~1.0.0-beta8",
+        "puli/cli": "~1.0.0-beta9"
     },
     "require-dev": {
         "php-http/httplug": "1.0.0-beta",
         "php-http/message-factory": "^1.0",
-        "puli/cli": "1.0.0-beta9",
         "phpspec/phpspec": "^2.4",
         "henrikbjorn/phpspec-code-coverage" : "^1.0"
     },


### PR DESCRIPTION
as per the discussion in https://github.com/FriendsOfSymfony/FOSHttpCache/pull/257/files#r48696611

for discovery to work, we need puli. discovery is all about ease of use, mostly a first impression thing (to properly configure your client, you want to instantiate/configure the client yourself). the first impression should be as smooth as possible. puli can't be expected to be globally installed in most systems. the worst that can happen here is that we unnecessarily install the puli cli in vendor. that seems pretty acceptable as worst case...