### PR TITLE
Added fallback on common classes. Puli is now optional

### DIFF
--- a/spec/ClassDiscoverySpec.php
+++ b/spec/ClassDiscoverySpec.php
@@ -47,7 +47,7 @@ class ClassDiscoverySpec extends ObjectBehavior
     {
         $discovery->findBindings('InvalidBinding')->willReturn([]);
 
-        $this->shouldThrow('Http\Discovery\NotFoundException')->duringFindOneByType('InvalidBinding');
+        $this->shouldThrow('Http\Discovery\Exception\NotFoundException')->duringFindOneByType('InvalidBinding');
     }
 
     function it_returns_a_class_binding(Discovery $discovery, ClassBinding $binding)

--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -106,7 +106,7 @@ abstract class ClassDiscovery
         } catch (PuliNotAvailableException $e) {
             if (false !== $class = HttpClients::findOneByType($type)) {
                 return $class;
-            }elseif (false !== $class = GuzzleFactory::findOneByType($type)) {
+            } elseif (false !== $class = GuzzleFactory::findOneByType($type)) {
                 return $class;
             } elseif (false !== $class = DiactorosFactory::findOneByType($type)) {
                 return $class;

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Http\Discovery;
+namespace Http\Discovery\Exception;
 
 /**
  * Thrown when a discovery does not find any matches.

--- a/src/Exception/PuliNotAvailableException.php
+++ b/src/Exception/PuliNotAvailableException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Http\Discovery\Exception;
+
+/**
+ * Thrown when we can't use Puli for discovery.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class PuliNotAvailableException extends \RuntimeException
+{
+
+}

--- a/src/Exception/PuliNotAvailableException.php
+++ b/src/Exception/PuliNotAvailableException.php
@@ -9,5 +9,4 @@ namespace Http\Discovery\Exception;
  */
 class PuliNotAvailableException extends \RuntimeException
 {
-
 }

--- a/src/FallbackStrategy/DiactorosFactory.php
+++ b/src/FallbackStrategy/DiactorosFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Http\Discovery\FallbackStrategy;
+
+/**
+ * Find Diactoros factories.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class DiactorosFactory implements FallbackStrategy
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function findOneByType($type)
+    {
+        if (!class_exists('Zend\Diactoros\Request')) {
+            return false;
+        }
+
+        switch ($type) {
+            case 'Http\Message\MessageFactory':
+                if (class_exists('Http\Message\MessageFactory\DiactorosMessageFactory')) {
+                    return 'Http\Message\MessageFactory\DiactorosMessageFactory';
+                }
+                break;
+            case 'Http\Message\StreamFactory':
+                if (class_exists('Http\Message\StreamFactory\DiactorosStreamFactory')) {
+                    return 'Http\Message\StreamFactory\DiactorosStreamFactory';
+                }
+                break;
+            case 'Http\Message\UriFactory':
+                if (class_exists('Http\Message\UriFactory\DiactorosUriFactory')) {
+                    return 'Http\Message\UriFactory\DiactorosUriFactory';
+                }
+                break;
+        }
+
+        return false;
+    }
+
+}

--- a/src/FallbackStrategy/DiactorosFactory.php
+++ b/src/FallbackStrategy/DiactorosFactory.php
@@ -38,5 +38,4 @@ class DiactorosFactory implements FallbackStrategy
 
         return false;
     }
-
 }

--- a/src/FallbackStrategy/FallbackStrategy.php
+++ b/src/FallbackStrategy/FallbackStrategy.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Http\Discovery\FallbackStrategy;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+interface FallbackStrategy
+{
+    /**
+     * @param $type
+     *
+     * @return string|bool class name of boolean false
+     */
+    public static function findOneByType($type);
+}

--- a/src/FallbackStrategy/GuzzleFactory.php
+++ b/src/FallbackStrategy/GuzzleFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Http\Discovery\FallbackStrategy;
+
+/**
+ * Find Guzzle factories.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class GuzzleFactory implements FallbackStrategy
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function findOneByType($type)
+    {
+        if (!class_exists('GuzzleHttp\Psr7\Request')) {
+            return false;
+        }
+
+        switch ($type) {
+            case 'Http\Message\MessageFactory':
+                if (class_exists('Http\Message\MessageFactory\GuzzleMessageFactory')) {
+                    return 'Http\Message\MessageFactory\GuzzleMessageFactory';
+                }
+                break;
+            case 'Http\Message\StreamFactory':
+                if (class_exists('Http\Message\StreamFactory\GuzzleStreamFactory')) {
+                    return 'Http\Message\StreamFactory\GuzzleStreamFactory';
+                }
+                break;
+            case 'Http\Message\UriFactory':
+                if (class_exists('Http\Message\UriFactory\GuzzleUriFactory')) {
+                    return 'Http\Message\UriFactory\GuzzleUriFactory';
+                }
+                break;
+        }
+
+        return false;
+    }
+}

--- a/src/FallbackStrategy/HttpClients.php
+++ b/src/FallbackStrategy/HttpClients.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Http\Discovery\FallbackStrategy;
+
+/**
+ * Find common HTTP clients.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class HttpClients implements FallbackStrategy
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function findOneByType($type)
+    {
+        switch ($type) {
+            case 'Http\Client\HttpAsyncClient':
+                $clients = ['Http\Adapter\Guzzle6\Client'];
+                foreach ($clients as $class) {
+                    if (class_exists($class)) {
+                        return $class;
+                    }
+                }
+                break;
+            case 'Http\Client\HttpClient':
+                $clients = ['Http\Adapter\Guzzle6\Client', 'Http\Adapter\Guzzle5\Client'];
+                foreach ($clients as $class) {
+                    if (class_exists($class)) {
+                        return $class;
+                    }
+                }
+                break;
+        }
+
+        return false;
+    }
+}

--- a/src/MessageFactoryDiscovery.php
+++ b/src/MessageFactoryDiscovery.php
@@ -2,6 +2,7 @@
 
 namespace Http\Discovery;
 
+use Http\Discovery\Exception\NotFoundException;
 use Http\Message\MessageFactory;
 
 /**

--- a/src/StreamFactoryDiscovery.php
+++ b/src/StreamFactoryDiscovery.php
@@ -2,6 +2,7 @@
 
 namespace Http\Discovery;
 
+use Http\Discovery\Exception\NotFoundException;
 use Http\Message\StreamFactory;
 
 /**

--- a/src/UriFactoryDiscovery.php
+++ b/src/UriFactoryDiscovery.php
@@ -2,6 +2,7 @@
 
 namespace Http\Discovery;
 
+use Http\Discovery\Exception\NotFoundException;
 use Http\Message\UriFactory;
 
 /**


### PR DESCRIPTION
This PR will make Puli optional as discussed in #55. 

## This is how discovery works 
Step 1) Use puli,
 * If puli does not find anything then we are done. 
 * If Puli is not installed we continue to step 2.

Step 2) See if we find any HttpClients

Step 3) Look for Guzzle factories, will succeed if `php-http/message` and `guzzlehttp/psr7` is installed

Step 4) Look for Diactoros factories, will succeed if `php-http/message` and `zendframework/zend-diactoros` is installed

## Changes:
* When Puli is missing we will not throw a `\RuntimeException` anymore. There will be a `NotFoundException`.
* The `NotFoundException` is moved from `Http\Discovery` to `Http\Discovery\Exception`

## TODO
This is just a proof of concept. Do we like to go this way?

* [ ] Add tests
* [ ] Update documentation