### PR TITLE
Flexible discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.9.0 - 2016-06-25
+
+### Changed
+
+- Support of multiple strategies to find classes. This will make Puli optional
+- Updated exceptions
 
 ## 0.8.0 - 2016-02-11
 

--- a/phpspec.yml.ci
+++ b/phpspec.yml.ci
@@ -7,3 +7,4 @@ extensions:
 code_coverage:
     format: clover
     output: build/coverage.xml
+bootstrap: spec/autoload.php

--- a/phpspec.yml.dist
+++ b/phpspec.yml.dist
@@ -3,3 +3,4 @@ suites:
         namespace: Http\Discovery
         psr4_prefix: Http\Discovery
 formatter.name: pretty
+bootstrap: spec/autoload.php

--- a/spec/ClassDiscoverySpec.php
+++ b/spec/ClassDiscoverySpec.php
@@ -3,29 +3,22 @@
 namespace spec\Http\Discovery;
 
 use Http\Discovery\ClassDiscovery;
+use Http\Discovery\Exception\DiscoveryFailedException;
+use Http\Discovery\Exception\NotFoundException;
+use Http\Discovery\Strategy\DiscoveryStrategy;
 use Puli\Discovery\Binding\ClassBinding;
 use Puli\GeneratedPuliFactory;
 use Puli\Discovery\Api\Discovery;
 use Puli\Repository\Api\ResourceRepository;
 use PhpSpec\ObjectBehavior;
+use spec\Http\Discovery\Helper\DiscoveryHelper;
 
 class ClassDiscoverySpec extends ObjectBehavior
 {
-    function let(
-        GeneratedPuliFactory $puliFactory,
-        ResourceRepository $repository,
-        Discovery $discovery
-    ) {
-        $puliFactory->createRepository()->willReturn($repository);
-        $puliFactory->createDiscovery($repository)->willReturn($discovery);
-
+    function let() {
+        ClassDiscovery::setStrategies([DiscoveryHelper::class]);
+        DiscoveryHelper::clearClasses();
         $this->beAnInstanceOf('spec\Http\Discovery\ClassDiscoveryStub');
-        $this->setPuliFactory($puliFactory);
-    }
-
-    function letgo()
-    {
-        $this->resetPuliFactory();
     }
 
     function it_is_initializable()
@@ -33,53 +26,35 @@ class ClassDiscoverySpec extends ObjectBehavior
         $this->shouldHaveType('Http\Discovery\ClassDiscovery');
     }
 
-    function it_has_a_puli_factory(GeneratedPuliFactory $puliFactory)
+    function it_throws_an_exception_when_no_candidate_found(DiscoveryStrategy $strategy)
     {
-        $this->getPuliFactory()->shouldReturn($puliFactory);
+        $strategy->getCandidates('NoCandidate')->willReturn([]);
+
+        $this->shouldThrow(DiscoveryFailedException::class)->duringFind('NoCandidate');
     }
 
-    function it_has_a_puli_discovery(Discovery $discovery)
+    function it_returns_a_class(DiscoveryStrategy $strategy)
     {
-        $this->getPuliDiscovery()->shouldReturn($discovery);
+        $candidate = ['class' => 'ClassName', 'condition' => true];
+        DiscoveryHelper::setClasses('Foobar', [$candidate]);
+
+        $this->find('Foobar')->shouldReturn('ClassName');
     }
 
-    function it_throws_an_exception_when_binding_not_found(Discovery $discovery)
-    {
-        $discovery->findBindings('InvalidBinding')->willReturn([]);
+    function it_validates_conditions(DiscoveryStrategy $strategy) {
+        $c0 = ['class' => 'ClassName0', 'condition' => false];
+        $c1 = ['class' => 'ClassName1', 'condition' => true];
+        $c2 = ['class' => 'ClassName2', 'condition' => false];
+        DiscoveryHelper::setClasses('Foobar', [$c0, $c1, $c2]);
 
-        $this->shouldThrow('Http\Discovery\NotFoundException')->duringFindOneByType('InvalidBinding');
-    }
-
-    function it_returns_a_class_binding(Discovery $discovery, ClassBinding $binding)
-    {
-        $binding->hasParameterValue('depends')->willReturn(false);
-        $binding->getClassName()->willReturn('ClassName');
-
-        $discovery->findBindings('Binding')->willReturn([$binding]);
-
-        $this->findOneByType('Binding')->shouldReturn('ClassName');
-    }
-
-    function it_returns_a_class_binding_with_dependency(
-        Discovery $discovery,
-        ClassBinding $binding1,
-        ClassBinding $binding2
-    ) {
-        $binding1->hasParameterValue('depends')->willReturn(true);
-        $binding1->getParameterValue('depends')->willReturn(false);
-
-        $binding2->hasParameterValue('depends')->willReturn(false);
-        $binding2->getClassName()->willReturn('ClassName');
-
-        $discovery->findBindings('Binding')->willReturn([
-            $binding1,
-            $binding2,
-        ]);
-
-        $this->findOneByType('Binding')->shouldReturn('ClassName');
+        $this->find('Foobar')->shouldReturn('ClassName1');
     }
 }
 
 class ClassDiscoveryStub extends ClassDiscovery
 {
+    public static function find($type)
+    {
+        return self::findOneByType($type);
+    }
 }

--- a/spec/Helper/DiscoveryHelper.php
+++ b/spec/Helper/DiscoveryHelper.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace spec\Http\Discovery\Helper;
+
+use Http\Discovery\Strategy\DiscoveryStrategy;
+
+/**
+ * This is a discovery helper used in tests
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class DiscoveryHelper implements DiscoveryStrategy
+{
+    private static $classes = [];
+
+    /**
+     * @param string $type
+     * @param array $classes
+     *
+     * @return $this
+     */
+    public static function setClasses($type, array $classes)
+    {
+        self::$classes[$type] = $classes;
+    }
+
+    /**
+     * Clear all classes.
+     */
+    public static function clearClasses()
+    {
+        self::$classes = [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getCandidates($type)
+    {
+        if (isset(static::$classes[$type])) {
+            return static::$classes[$type];
+        }
+
+        return [];
+    }
+}

--- a/spec/Strategy/PuliSpec.php
+++ b/spec/Strategy/PuliSpec.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace spec\Http\Discovery\Strategy;
+
+use Http\Discovery\ClassDiscovery;
+use Http\Discovery\Exception\NotFoundException;
+use Http\Discovery\Strategy\Puli;
+use Puli\Discovery\Binding\ClassBinding;
+use Puli\GeneratedPuliFactory;
+use Puli\Discovery\Api\Discovery;
+use Puli\Repository\Api\ResourceRepository;
+use PhpSpec\ObjectBehavior;
+
+class PuliSpec extends ObjectBehavior
+{
+    function let(
+        GeneratedPuliFactory $puliFactory,
+        ResourceRepository $repository,
+        Discovery $discovery
+    ) {
+        $puliFactory->createRepository()->willReturn($repository);
+        $puliFactory->createDiscovery($repository)->willReturn($discovery);
+        $this->beAnInstanceOf('spec\Http\Discovery\Strategy\PuliStub');
+        $this->setPuliFactory($puliFactory);
+    }
+
+    function letgo()
+    {
+        $this->resetPuliFactory();
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Http\Discovery\Strategy\Puli');
+    }
+
+    function it_returns_a_class_binding(Discovery $discovery, ClassBinding $binding)
+    {
+        $binding->hasParameterValue('depends')->willReturn(false);
+        $binding->getClassName()->willReturn('ClassName');
+
+        $discovery->findBindings('Binding')->willReturn([$binding]);
+
+        $this->getCandidates('Binding')->shouldHaveCandidate('ClassName', true);
+    }
+
+    function it_returns_a_class_binding_with_dependency(
+        Discovery $discovery,
+        ClassBinding $binding1,
+        ClassBinding $binding2
+    ) {
+        $binding1->hasParameterValue('depends')->willReturn(true);
+        $binding1->getParameterValue('depends')->willReturn('foobar');
+        $binding1->getClassName()->willReturn('ClassName1');
+
+
+        $binding2->hasParameterValue('depends')->willReturn(false);
+        $binding2->getClassName()->willReturn('ClassName2');
+
+        $discovery->findBindings('Binding')->willReturn([
+            $binding1,
+            $binding2,
+        ]);
+
+        $this->getCandidates('Binding')->shouldHaveCandidate('ClassName1', 'foobar');
+        $this->getCandidates('Binding')->shouldHaveCandidate('ClassName2', true);
+    }
+
+
+    public function getMatchers()
+    {
+        return [
+            'haveCandidate' => function ($subject, $class, $condition) {
+                foreach ($subject as $candidate) {
+                    if ($candidate['class'] === $class && $candidate['condition'] === $condition) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        ];
+    }
+}
+
+class PuliStub extends Puli
+{
+    /**
+     * Sets the Puli factory.
+     *
+     * @param object $puliFactory
+     */
+    public static function setPuliFactory($puliFactory)
+    {
+        if (!is_callable([$puliFactory, 'createRepository']) || !is_callable([$puliFactory, 'createDiscovery'])) {
+            throw new \InvalidArgumentException('The Puli Factory must expose a repository and a discovery');
+        }
+        self::$puliFactory = $puliFactory;
+        self::$puliDiscovery = null;
+    }
+    /**
+     * Resets the factory.
+     */
+    public static function resetPuliFactory()
+    {
+        self::$puliFactory = null;
+        self::$puliDiscovery = null;
+    }
+}

--- a/spec/StreamFactoryDiscoverySpec.php
+++ b/spec/StreamFactoryDiscoverySpec.php
@@ -2,28 +2,23 @@
 
 namespace spec\Http\Discovery;
 
+use Http\Discovery\ClassDiscovery;
+use Http\Discovery\Exception\NotFoundException;
+use Http\Discovery\Strategy\DiscoveryStrategy;
+use Http\Message\StreamFactory;
 use Puli\GeneratedPuliFactory;
 use Puli\Discovery\Api\Discovery;
 use Puli\Discovery\Binding\ClassBinding;
 use Puli\Repository\Api\ResourceRepository;
 use PhpSpec\ObjectBehavior;
+use spec\Http\Discovery\Helper\DiscoveryHelper;
 
 class StreamFactoryDiscoverySpec extends ObjectBehavior
 {
-    function let(
-        GeneratedPuliFactory $puliFactory,
-        ResourceRepository $repository,
-        Discovery $discovery
-    ) {
-        $puliFactory->createRepository()->willReturn($repository);
-        $puliFactory->createDiscovery($repository)->willReturn($discovery);
-
-        $this->setPuliFactory($puliFactory);
-    }
-
-    function letgo()
+    function let()
     {
-        $this->resetPuliFactory();
+        ClassDiscovery::setStrategies([DiscoveryHelper::class]);
+        DiscoveryHelper::clearClasses();
     }
 
     function it_is_initializable()
@@ -36,15 +31,17 @@ class StreamFactoryDiscoverySpec extends ObjectBehavior
         $this->shouldHaveType('Http\Discovery\ClassDiscovery');
     }
 
-    function it_finds_a_stream_factory(
-        Discovery $discovery,
-        ClassBinding $binding
-    ) {
-        $binding->hasParameterValue('depends')->willReturn(false);
-        $binding->getClassName()->willReturn('spec\Http\Discovery\Stub\StreamFactoryStub');
+    function it_finds_a_stream_factory(DiscoveryStrategy $strategy) {
 
-        $discovery->findBindings('Http\Message\StreamFactory')->willReturn([$binding]);
+        $candidate = ['class' => 'spec\Http\Discovery\Stub\StreamFactoryStub', 'condition' => true];
+        DiscoveryHelper::setClasses(StreamFactory::class, [$candidate]);
 
         $this->find()->shouldImplement('Http\Message\StreamFactory');
+    }
+
+    function it_throw_exception(DiscoveryStrategy $strategy) {
+        $strategy->getCandidates('Http\Message\StreamFactory')->willReturn([]);
+
+        $this->shouldThrow(NotFoundException::class)->duringFind();
     }
 }

--- a/spec/autoload.php
+++ b/spec/autoload.php
@@ -1,0 +1,9 @@
+<?php
+$loader = require __DIR__.'/../vendor/autoload.php';
+
+// Temporary fix for Puli
+if (PHP_VERSION_ID >= 50600) {
+    $loader->addClassMap([
+        'Puli\\GeneratedPuliFactory' => __DIR__.'/../.puli/GeneratedPuliFactory.php',
+    ]);
+}

--- a/src/Exception/DiscoveryFailedException.php
+++ b/src/Exception/DiscoveryFailedException.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Http\Discovery\Exception;
+
+/**
+ * Thrown when all discovery strategies fails to find a resource.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+final class DiscoveryFailedException extends \Exception
+{
+    /**
+     * @var array
+     */
+    private $exceptions;
+
+    /**
+     * @param $exceptions
+     */
+    public function __construct($message, array $exceptions = [])
+    {
+        $this->exceptions = $exceptions;
+
+        parent::__construct($message, 0, array_shift($exceptions));
+    }
+
+    /**
+     * @return array
+     */
+    public function getExceptions()
+    {
+        return $this->exceptions;
+    }
+}

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Http\Discovery;
+namespace Http\Discovery\Exception;
 
 /**
  * Thrown when a discovery does not find any matches.

--- a/src/Exception/PuliUnavailableException.php
+++ b/src/Exception/PuliUnavailableException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Http\Discovery\Exception;
+
+/**
+ * Thrown when we can't use Puli for discovery.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class PuliUnavailableException extends StrategyUnavailableException
+{
+}

--- a/src/Exception/StrategyUnavailableException.php
+++ b/src/Exception/StrategyUnavailableException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Http\Discovery\Exception;
+
+/**
+ * This exception is thrown when we cannot use a discovery strategy. This is *not* thrown when
+ * the discovery fails to find a class.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class StrategyUnavailableException extends \RuntimeException
+{
+}

--- a/src/HttpAsyncClientDiscovery.php
+++ b/src/HttpAsyncClientDiscovery.php
@@ -3,6 +3,8 @@
 namespace Http\Discovery;
 
 use Http\Client\HttpAsyncClient;
+use Http\Discovery\Exception\DiscoveryFailedException;
+use Http\Discovery\Exception\NotFoundException;
 
 /**
  * Finds an HTTP Asynchronous Client.
@@ -15,11 +17,21 @@ final class HttpAsyncClientDiscovery extends ClassDiscovery
      * Finds an HTTP Async Client.
      *
      * @return HttpAsyncClient
+     *
+     * @throws NotFoundException
      */
     public static function find()
     {
-        $asyncClient = static::findOneByType('Http\Client\HttpAsyncClient');
+        try {
+            $asyncClient = static::findOneByType(HttpAsyncClient::class);
 
-        return new $asyncClient();
+            return new $asyncClient();
+        } catch (DiscoveryFailedException $e) {
+            throw new NotFoundException(
+                'No HTTPlug async clients found. Make sure to install a package providing "php-http/async-client-implementation". Example: "php-http/guzzle6-adapter".',
+                0,
+                $e
+            );
+        }
     }
 }

--- a/src/HttpClientDiscovery.php
+++ b/src/HttpClientDiscovery.php
@@ -3,6 +3,8 @@
 namespace Http\Discovery;
 
 use Http\Client\HttpClient;
+use Http\Discovery\Exception\DiscoveryFailedException;
+use Http\Discovery\Exception\NotFoundException;
 
 /**
  * Finds an HTTP Client.
@@ -15,11 +17,21 @@ final class HttpClientDiscovery extends ClassDiscovery
      * Finds an HTTP Client.
      *
      * @return HttpClient
+     *
+     * @throws NotFoundException
      */
     public static function find()
     {
-        $client = static::findOneByType('Http\Client\HttpClient');
+        try {
+            $client = static::findOneByType(HttpClient::class);
 
-        return new $client();
+            return new $client();
+        } catch (DiscoveryFailedException $e) {
+            throw new NotFoundException(
+                'No HTTPlug clients found. Make sure to install a package providing "php-http/client-implementation". Example: "php-http/guzzle6-adapter".',
+                0,
+                $e
+            );
+        }
     }
 }

--- a/src/MessageFactoryDiscovery.php
+++ b/src/MessageFactoryDiscovery.php
@@ -2,6 +2,8 @@
 
 namespace Http\Discovery;
 
+use Http\Discovery\Exception\DiscoveryFailedException;
+use Http\Discovery\Exception\NotFoundException;
 use Http\Message\MessageFactory;
 
 /**
@@ -15,16 +17,18 @@ final class MessageFactoryDiscovery extends ClassDiscovery
      * Finds a Message Factory.
      *
      * @return MessageFactory
+     *
+     * @throws NotFoundException
      */
     public static function find()
     {
         try {
-            $messageFactory = static::findOneByType('Http\Message\MessageFactory');
+            $messageFactory = static::findOneByType(MessageFactory::class);
 
             return new $messageFactory();
-        } catch (NotFoundException $e) {
+        } catch (DiscoveryFailedException $e) {
             throw new NotFoundException(
-                'No factories found. To use Guzzle or Diactoros factories install php-http/message and the chosen message implementation.',
+                'No message factories found. To use Guzzle or Diactoros factories install php-http/message and the chosen message implementation.',
                 0,
                 $e
             );

--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Http\Discovery\Strategy;
+
+use GuzzleHttp\Psr7\Request as GuzzleRequest;
+use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Http\Message\StreamFactory\GuzzleStreamFactory;
+use Http\Message\UriFactory\GuzzleUriFactory;
+use Http\Message\MessageFactory\DiactorosMessageFactory;
+use Http\Message\StreamFactory\DiactorosStreamFactory;
+use Http\Message\UriFactory\DiactorosUriFactory;
+use Zend\Diactoros\Request as DiactorosRequest;
+use Http\Adapter\Guzzle6\Client as Guzzle6;
+use Http\Adapter\Guzzle5\Client as Guzzle5;
+use Http\Client\Curl\Client as Curl;
+use Http\Client\Socket\Client as Socket;
+use Http\Adapter\React\Client as React;
+use Http\Adapter\Buzz\Client as Buzz;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class CommonClassesStrategy implements DiscoveryStrategy
+{
+    /**
+     * @var array
+     */
+    private static $classes = [
+        'Http\Message\MessageFactory' => [
+            ['class' => GuzzleMessageFactory::class, 'condition' => [GuzzleRequest::class, GuzzleMessageFactory::class]],
+            ['class' => DiactorosMessageFactory::class, 'condition' => [DiactorosRequest::class, DiactorosMessageFactory::class]],
+        ],
+        'Http\Message\StreamFactory' => [
+            ['class' => GuzzleStreamFactory::class, 'condition' => [GuzzleRequest::class, GuzzleStreamFactory::class]],
+            ['class' => DiactorosStreamFactory::class, 'condition' => [DiactorosRequest::class, DiactorosStreamFactory::class]],
+        ],
+        'Http\Message\UriFactory' => [
+            ['class' => GuzzleUriFactory::class, 'condition' => [GuzzleRequest::class, GuzzleUriFactory::class]],
+            ['class' => DiactorosUriFactory::class, 'condition' => [DiactorosRequest::class, DiactorosUriFactory::class]],
+        ],
+        'Http\Client\HttpAsyncClient' => [
+            ['class' => Guzzle6::class, 'condition' => Guzzle6::class],
+            ['class' => Curl::class, 'condition' => Curl::class],
+            ['class' => React::class, 'condition' => React::class],
+        ],
+        'Http\Client\HttpClient' => [
+            ['class' => Guzzle6::class, 'condition' => Guzzle6::class],
+            ['class' => Guzzle5::class, 'condition' => Guzzle5::class],
+            ['class' => Curl::class, 'condition' => Curl::class],
+            ['class' => Socket::class, 'condition' => Socket::class],
+            ['class' => Buzz::class, 'condition' => Buzz::class],
+            ['class' => React::class, 'condition' => React::class],
+        ],
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getCandidates($type)
+    {
+        if (isset(static::$classes[$type])) {
+            return static::$classes[$type];
+        }
+
+        return [];
+    }
+}

--- a/src/Strategy/DiscoveryStrategy.php
+++ b/src/Strategy/DiscoveryStrategy.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Http\Discovery\Strategy;
+
+use Http\Discovery\Exception\StrategyUnavailableException;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+interface DiscoveryStrategy
+{
+    /**
+     * Find a resource of a specific type.
+     *
+     * @param string $type
+     *
+     * @return array The return value is always an array with zero or more elements. Each
+     *               element is an array with two keys ['class' => string, 'condition' => mixed].
+     *
+     * @throws StrategyUnavailableException if we cannot use this strategy.
+     */
+    public static function getCandidates($type);
+}

--- a/src/Strategy/Puli.php
+++ b/src/Strategy/Puli.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Http\Discovery\Strategy;
+
+use Http\Discovery\Exception\PuliUnavailableException;
+use Puli\Discovery\Api\Discovery;
+use Puli\GeneratedPuliFactory;
+
+/**
+ * Find candidates using Puli.
+ *
+ * @internal
+ *
+ * @author David de Boer <david@ddeboer.nl>
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+class Puli implements DiscoveryStrategy
+{
+    /**
+     * @var GeneratedPuliFactory
+     */
+    protected static $puliFactory;
+
+    /**
+     * @var Discovery
+     */
+    protected static $puliDiscovery;
+
+    /**
+     * @return GeneratedPuliFactory
+     *
+     * @throws PuliUnavailableException
+     */
+    private static function getPuliFactory()
+    {
+        if (null === self::$puliFactory) {
+            if (!defined('PULI_FACTORY_CLASS')) {
+                throw new PuliUnavailableException('Puli Factory is not available');
+            }
+
+            $puliFactoryClass = PULI_FACTORY_CLASS;
+
+            if (!class_exists($puliFactoryClass)) {
+                throw new PuliUnavailableException('Puli Factory class does not exist');
+            }
+
+            self::$puliFactory = new $puliFactoryClass();
+        }
+
+        return self::$puliFactory;
+    }
+
+    /**
+     * Returns the Puli discovery layer.
+     *
+     * @return Discovery
+     *
+     * @throws PuliUnavailableException
+     */
+    private static function getPuliDiscovery()
+    {
+        if (!isset(self::$puliDiscovery)) {
+            $factory = self::getPuliFactory();
+            $repository = $factory->createRepository();
+
+            self::$puliDiscovery = $factory->createDiscovery($repository);
+        }
+
+        return self::$puliDiscovery;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getCandidates($type)
+    {
+        $returnData = [];
+        $bindings = self::getPuliDiscovery()->findBindings($type);
+
+        foreach ($bindings as $binding) {
+            $condition = true;
+            if ($binding->hasParameterValue('depends')) {
+                $condition = $binding->getParameterValue('depends');
+            }
+            $returnData[] = ['class' => $binding->getClassName(), 'condition' => $condition];
+        }
+
+        return $returnData;
+    }
+}

--- a/src/StreamFactoryDiscovery.php
+++ b/src/StreamFactoryDiscovery.php
@@ -2,6 +2,8 @@
 
 namespace Http\Discovery;
 
+use Http\Discovery\Exception\DiscoveryFailedException;
+use Http\Discovery\Exception\NotFoundException;
 use Http\Message\StreamFactory;
 
 /**
@@ -15,16 +17,18 @@ final class StreamFactoryDiscovery extends ClassDiscovery
      * Finds a Stream Factory.
      *
      * @return StreamFactory
+     *
+     * @throws NotFoundException
      */
     public static function find()
     {
         try {
-            $streamFactory = static::findOneByType('Http\Message\StreamFactory');
+            $streamFactory = static::findOneByType(StreamFactory::class);
 
             return new $streamFactory();
-        } catch (NotFoundException $e) {
+        } catch (DiscoveryFailedException $e) {
             throw new NotFoundException(
-                'No factories found. To use Guzzle or Diactoros factories install php-http/message and the chosen message implementation.',
+                'No stream factories found. To use Guzzle or Diactoros factories install php-http/message and the chosen message implementation.',
                 0,
                 $e
             );

--- a/src/UriFactoryDiscovery.php
+++ b/src/UriFactoryDiscovery.php
@@ -2,6 +2,8 @@
 
 namespace Http\Discovery;
 
+use Http\Discovery\Exception\DiscoveryFailedException;
+use Http\Discovery\Exception\NotFoundException;
 use Http\Message\UriFactory;
 
 /**
@@ -15,16 +17,18 @@ final class UriFactoryDiscovery extends ClassDiscovery
      * Finds a URI Factory.
      *
      * @return UriFactory
+     *
+     * @throws NotFoundException
      */
     public static function find()
     {
         try {
-            $uriFactory = static::findOneByType('Http\Message\UriFactory');
+            $uriFactory = static::findOneByType(UriFactory::class);
 
             return new $uriFactory();
-        } catch (NotFoundException $e) {
+        } catch (DiscoveryFailedException $e) {
             throw new NotFoundException(
-                'No factories found. To use Guzzle or Diactoros factories install php-http/message and the chosen message implementation.',
+                'No uri factories found. To use Guzzle or Diactoros factories install php-http/message and the chosen message implementation.',
                 0,
                 $e
             );


### PR DESCRIPTION
I was not too happy about #58. We treat Puli in a special manner which feels weird. Also, I was not too happy about the logic in the fallback strategies. 

This PR continues the work and replaces #58. The user has now the possibility to select what strategies to use and also add some more custom if there is a need for it. 

## Changes
* Introduced `Stratiegies` that do the discovery. We try the strategies one by one until we find what we're looking for
* many public functions are moved from `ClassDiscovery` to `Strategy\Puli`. 
* I've also created some new exceptions. 
* Added a simple cache mechanism
* When Puli is missing we will not throw a \RuntimeException anymore. There will be a NotFoundException which has previous exception so you can see that Puli was missing. 
* The NotFoundException is moved from Http\Discovery to Http\Discovery\Exception


## TODO
This is just a proof of concept. Do we like to go this way?

* [x] Add tests
* [ ] Update documentation