### PR TITLE
Allow for a candidate to have a Closure as a class parameter

### DIFF
--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -2,6 +2,7 @@
 
 namespace Http\Discovery;
 
+use Http\Discovery\Exception\ClassinstantiationFailedException;
 use Http\Discovery\Exception\DiscoveryFailedException;
 use Http\Discovery\Exception\StrategyUnavailableException;
 
@@ -36,7 +37,7 @@ abstract class ClassDiscovery
      *
      * @param string $type
      *
-     * @return string
+     * @return string|\Closure
      *
      * @throws DiscoveryFailedException
      */
@@ -176,5 +177,29 @@ abstract class ClassDiscovery
         }
 
         return false;
+    }
+
+    /**
+     * Get an instance of the $class.
+     *
+     * @param string|\Closure $class A FQN of a class or a closure that instantiate the class.
+     *
+     * @return object
+     */
+    protected static function instantiateClass($class)
+    {
+        try {
+            if (is_string($class)) {
+                return new $class();
+            }
+
+            if (is_callable($class)) {
+                return $class();
+            }
+        } catch (\Exception $e) {
+            throw new ClassinstantiationFailedException('Unexcepced exception when instantiating class.', 0, $e);
+        }
+        
+        throw new ClassinstantiationFailedException('Could not instantiate class becuase parameter is neitehr a callable or a string');
     }
 }

--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -199,7 +199,7 @@ abstract class ClassDiscovery
         } catch (\Exception $e) {
             throw new ClassinstantiationFailedException('Unexcepced exception when instantiating class.', 0, $e);
         }
-        
+
         throw new ClassinstantiationFailedException('Could not instantiate class becuase parameter is neitehr a callable or a string');
     }
 }

--- a/src/Exception/ClassinstantiationFailedException.php
+++ b/src/Exception/ClassinstantiationFailedException.php
@@ -2,11 +2,13 @@
 
 namespace Http\Discovery\Exception;
 
+use Http\Discovery\Exception;
+
 /**
  * Thrown when a class fails to instantiate.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class ClassinstantiationFailedException extends \RuntimeException
+class ClassinstantiationFailedException extends \RuntimeException implements Exception
 {
 }

--- a/src/Exception/ClassinstantiationFailedException.php
+++ b/src/Exception/ClassinstantiationFailedException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Http\Discovery\Exception;
+
+/**
+ * Thrown when a class fails to instantiate.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class ClassinstantiationFailedException extends \RuntimeException
+{
+}

--- a/src/HttpAsyncClientDiscovery.php
+++ b/src/HttpAsyncClientDiscovery.php
@@ -24,7 +24,7 @@ final class HttpAsyncClientDiscovery extends ClassDiscovery
         try {
             $asyncClient = static::findOneByType(HttpAsyncClient::class);
 
-            return new $asyncClient();
+            return static::instantiateClass($asyncClient);
         } catch (DiscoveryFailedException $e) {
             throw new NotFoundException(
                 'No HTTPlug async clients found. Make sure to install a package providing "php-http/async-client-implementation". Example: "php-http/guzzle6-adapter".',

--- a/src/HttpClientDiscovery.php
+++ b/src/HttpClientDiscovery.php
@@ -24,7 +24,7 @@ final class HttpClientDiscovery extends ClassDiscovery
         try {
             $client = static::findOneByType(HttpClient::class);
 
-            return new $client();
+            return static::instantiateClass($client);
         } catch (DiscoveryFailedException $e) {
             throw new NotFoundException(
                 'No HTTPlug clients found. Make sure to install a package providing "php-http/client-implementation". Example: "php-http/guzzle6-adapter".',

--- a/src/MessageFactoryDiscovery.php
+++ b/src/MessageFactoryDiscovery.php
@@ -23,7 +23,7 @@ final class MessageFactoryDiscovery extends ClassDiscovery
     {
         try {
             $messageFactory = static::findOneByType(MessageFactory::class);
-            
+
             return static::instantiateClass($messageFactory);
         } catch (DiscoveryFailedException $e) {
             throw new NotFoundException(

--- a/src/MessageFactoryDiscovery.php
+++ b/src/MessageFactoryDiscovery.php
@@ -23,8 +23,8 @@ final class MessageFactoryDiscovery extends ClassDiscovery
     {
         try {
             $messageFactory = static::findOneByType(MessageFactory::class);
-
-            return new $messageFactory();
+            
+            return static::instantiateClass($messageFactory);
         } catch (DiscoveryFailedException $e) {
             throw new NotFoundException(
                 'No message factories found. To use Guzzle or Diactoros factories install php-http/message and the chosen message implementation.',

--- a/src/StreamFactoryDiscovery.php
+++ b/src/StreamFactoryDiscovery.php
@@ -24,7 +24,7 @@ final class StreamFactoryDiscovery extends ClassDiscovery
         try {
             $streamFactory = static::findOneByType(StreamFactory::class);
 
-            return new $streamFactory();
+            return static::instantiateClass($streamFactory);
         } catch (DiscoveryFailedException $e) {
             throw new NotFoundException(
                 'No stream factories found. To use Guzzle or Diactoros factories install php-http/message and the chosen message implementation.',

--- a/src/UriFactoryDiscovery.php
+++ b/src/UriFactoryDiscovery.php
@@ -24,7 +24,7 @@ final class UriFactoryDiscovery extends ClassDiscovery
         try {
             $uriFactory = static::findOneByType(UriFactory::class);
 
-            return new $uriFactory();
+            return static::instantiateClass($uriFactory);
         } catch (DiscoveryFailedException $e) {
             throw new NotFoundException(
                 'No uri factories found. To use Guzzle or Diactoros factories install php-http/message and the chosen message implementation.',


### PR DESCRIPTION
This PR will allow you to return a closure as a class parameter on the candidate. The good thing about this is that someone can write their own strategy that emulates a async client. An example of such strategy is seen in #65. 

This will increase the extendibility in the discovery mechanism. 