### PR TITLE
Base exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 - Added back `Http\Discovery\NotFoundException` to preserve BC with 0.8 version
+- Added interface `Http\Discovery\Exception` which is implemented by all our exceptions
 
 ### Changed
 

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Http\Discovery;
+
+/**
+ * An interface implemented by all discovery related exceptions.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+interface Exception
+{
+}

--- a/src/Exception/DiscoveryFailedException.php
+++ b/src/Exception/DiscoveryFailedException.php
@@ -2,12 +2,14 @@
 
 namespace Http\Discovery\Exception;
 
+use Http\Discovery\Exception;
+
 /**
  * Thrown when all discovery strategies fails to find a resource.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class DiscoveryFailedException extends \Exception
+final class DiscoveryFailedException extends \Exception implements Exception
 {
     /**
      * @var array

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -2,6 +2,8 @@
 
 namespace Http\Discovery\Exception;
 
+use Http\Discovery\Exception;
+
 /**
  * Thrown when a discovery does not find any matches.
  *
@@ -9,6 +11,6 @@ namespace Http\Discovery\Exception;
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
  */
-/*final */class NotFoundException extends \RuntimeException
+/*final */class NotFoundException extends \RuntimeException implements Exception
 {
 }

--- a/src/Exception/StrategyUnavailableException.php
+++ b/src/Exception/StrategyUnavailableException.php
@@ -2,12 +2,14 @@
 
 namespace Http\Discovery\Exception;
 
+use Http\Discovery\Exception;
+
 /**
  * This exception is thrown when we cannot use a discovery strategy. This is *not* thrown when
  * the discovery fails to find a class.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class StrategyUnavailableException extends \RuntimeException
+class StrategyUnavailableException extends \RuntimeException implements Exception
 {
 }


### PR DESCRIPTION
Writing #66 made me think of introducing a base exception that all our exception extends from. This will make it easier to catch a discovery exception in case something goes wrong. 

This will be extra relevant if #66 gets merged because it introduces another exception. 