### PR TITLE
Discovery support for Slim Framework factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 
 
+## Unreleased
+
+### Added
+
+- Discovery support for Slim Framework factories
+
 ## 1.0.0 - 2016-07-18
 
 ### Added

--- a/src/MessageFactoryDiscovery.php
+++ b/src/MessageFactoryDiscovery.php
@@ -25,7 +25,7 @@ final class MessageFactoryDiscovery extends ClassDiscovery
             $messageFactory = static::findOneByType(MessageFactory::class);
         } catch (DiscoveryFailedException $e) {
             throw new NotFoundException(
-                'No message factories found. To use Guzzle or Diactoros factories install php-http/message and the chosen message implementation.',
+                'No message factories found. To use Guzzle, Diactoros or Slim Framework factories install php-http/message and the chosen message implementation.',
                 0,
                 $e
             );

--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -10,6 +10,10 @@ use Http\Message\MessageFactory\DiactorosMessageFactory;
 use Http\Message\StreamFactory\DiactorosStreamFactory;
 use Http\Message\UriFactory\DiactorosUriFactory;
 use Zend\Diactoros\Request as DiactorosRequest;
+use Http\Message\MessageFactory\SlimMessageFactory;
+use Http\Message\StreamFactory\SlimStreamFactory;
+use Http\Message\UriFactory\SlimUriFactory;
+use Slim\Http\Request as SlimRequest;
 use Http\Adapter\Guzzle6\Client as Guzzle6;
 use Http\Adapter\Guzzle5\Client as Guzzle5;
 use Http\Client\Curl\Client as Curl;
@@ -31,14 +35,17 @@ final class CommonClassesStrategy implements DiscoveryStrategy
         'Http\Message\MessageFactory' => [
             ['class' => GuzzleMessageFactory::class, 'condition' => [GuzzleRequest::class, GuzzleMessageFactory::class]],
             ['class' => DiactorosMessageFactory::class, 'condition' => [DiactorosRequest::class, DiactorosMessageFactory::class]],
+            ['class' => SlimMessageFactory::class, 'condition' => [SlimRequest::class, SlimMessageFactory::class]],
         ],
         'Http\Message\StreamFactory' => [
             ['class' => GuzzleStreamFactory::class, 'condition' => [GuzzleRequest::class, GuzzleStreamFactory::class]],
             ['class' => DiactorosStreamFactory::class, 'condition' => [DiactorosRequest::class, DiactorosStreamFactory::class]],
+            ['class' => SlimStreamFactory::class, 'condition' => [SlimRequest::class, SlimStreamFactory::class]],
         ],
         'Http\Message\UriFactory' => [
             ['class' => GuzzleUriFactory::class, 'condition' => [GuzzleRequest::class, GuzzleUriFactory::class]],
             ['class' => DiactorosUriFactory::class, 'condition' => [DiactorosRequest::class, DiactorosUriFactory::class]],
+            ['class' => SlimUriFactory::class, 'condition' => [SlimRequest::class, SlimUriFactory::class]],
         ],
         'Http\Client\HttpAsyncClient' => [
             ['class' => Guzzle6::class, 'condition' => Guzzle6::class],

--- a/src/StreamFactoryDiscovery.php
+++ b/src/StreamFactoryDiscovery.php
@@ -25,7 +25,7 @@ final class StreamFactoryDiscovery extends ClassDiscovery
             $streamFactory = static::findOneByType(StreamFactory::class);
         } catch (DiscoveryFailedException $e) {
             throw new NotFoundException(
-                'No stream factories found. To use Guzzle or Diactoros factories install php-http/message and the chosen message implementation.',
+                'No stream factories found. To use Guzzle, Diactoros or Slim Framework factories install php-http/message and the chosen message implementation.',
                 0,
                 $e
             );

--- a/src/UriFactoryDiscovery.php
+++ b/src/UriFactoryDiscovery.php
@@ -25,7 +25,7 @@ final class UriFactoryDiscovery extends ClassDiscovery
             $uriFactory = static::findOneByType(UriFactory::class);
         } catch (DiscoveryFailedException $e) {
             throw new NotFoundException(
-                'No uri factories found. To use Guzzle or Diactoros factories install php-http/message and the chosen message implementation.',
+                'No uri factories found. To use Guzzle, Diactoros or Slim Framework factories install php-http/message and the chosen message implementation.',
                 0,
                 $e
             );


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/php-http/message/pull/55 https://github.com/php-http/message/pull/53
| Documentation   |
| License         | MIT

#### What's in this PR?

Adds discovery support for Slim Framework factories when not using Puli.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)

