### PR TITLE
Using 'self' instead of 'static'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## Unreleased
 
+### Changed
+
+- `CommonClassesStrategy` is using `self` instead of `static`. Using `static` makes no sense when `CommonClassesStrategy` is final. 
+
 ## 1.1.0 - 2016-10-20
 
 ### Added

--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -67,8 +67,8 @@ final class CommonClassesStrategy implements DiscoveryStrategy
      */
     public static function getCandidates($type)
     {
-        if (isset(static::$classes[$type])) {
-            return static::$classes[$type];
+        if (isset(self::$classes[$type])) {
+            return self::$classes[$type];
         }
 
         return [];


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | n/a
| License         | MIT


#### Why

Scrutinizer suggest to change `self` to `static`. Since the `CommonClassesStrategy` is make no sense to have `static`.