### PR TITLE
Add Mock client to common classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 ### Changed
 
 - Made exception messages clearer. `StrategyUnavailableException` is no longer the previous exception to `DiscoveryFailedException`.
-- `CommonClassesStrategy` is using `self` instead of `static`. Using `static` makes no sense when `CommonClassesStrategy` is final. 
+- `CommonClassesStrategy` is using `self` instead of `static`. Using `static` makes no sense when `CommonClassesStrategy` is final.
+- Made `Http\Mock\Client` discoverable via `CommonClassesStrategy` without Puli dependency.
 
 ## 1.1.0 - 2016-10-20
 

--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -20,6 +20,7 @@ use Http\Client\Curl\Client as Curl;
 use Http\Client\Socket\Client as Socket;
 use Http\Adapter\React\Client as React;
 use Http\Adapter\Buzz\Client as Buzz;
+use Http\Mock\Client as Mock;
 
 /**
  * @internal
@@ -59,6 +60,7 @@ final class CommonClassesStrategy implements DiscoveryStrategy
             ['class' => Socket::class, 'condition' => Socket::class],
             ['class' => Buzz::class, 'condition' => Buzz::class],
             ['class' => React::class, 'condition' => React::class],
+            ['class' => Mock::class, 'condition' => Mock::class],
         ],
     ];
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    |no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | [#55](https://github.com/php-http/discovery/issues/55)
| Documentation   | 
| License         | MIT


#### What's in this PR?

This PR adds the `php-http/mock-client` to the list of discoverable classes via the Common Classes Strategy.

#### Why?

Since Puli is not a hard dependency on this package, all php-http clients should be able to be discovered via the discovery. Since package developers using `php-http` are likely to rely on the Mock client in tests, it is useful to make this client discoverable for better unit testing.


#### Example Usage

``` php
// ThirdPartyService.php

use Http\Client\HttpClient;
use Http\Discovery\HttpClientDiscovery;

class ThirdPartyService
{
    public function __construct(HttpClient $http = null)
    {
        $this->http = $http ?: HttpClientDiscovery::find();
    }
}
```

Now, before this PR, if we were to pass no value into `ThirdPartyService`'s constructor, the code would fail complaining about missing Puli dependency (assuming our package requires only `php-http/mock-client`). That means the following test in our package will fail:

```php
// ThirdPartyServiceTest.php

use ThirdPartyService

class ThirdPartyServiceTest extends PHPUnit_Framework_TestCase
{
    public function setUp()
    {
        $this->service = new ThirdPartyService;
    }
}
```

This PR fixes that issue and allows the above test to pass, without requiring Puli and using the Mock HTTP client.

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here