### PR TITLE
Add Mock Client strategy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,16 @@
 
 ## Unreleased
 
+### Added
+
+- MockClientStrategy class.
+
 ## 1.1.1 - 2016-11-27
 
 ### Changed
 
 - Made exception messages clearer. `StrategyUnavailableException` is no longer the previous exception to `DiscoveryFailedException`.
-- `CommonClassesStrategy` is using `self` instead of `static`. Using `static` makes no sense when `CommonClassesStrategy` is final. 
+- `CommonClassesStrategy` is using `self` instead of `static`. Using `static` makes no sense when `CommonClassesStrategy` is final.
 
 ## 1.1.0 - 2016-10-20
 

--- a/src/Strategy/MockClientStrategy.php
+++ b/src/Strategy/MockClientStrategy.php
@@ -7,9 +7,6 @@ use Http\Mock\Client as Mock;
 /**
  * Find the Mock client.
  *
- * @internal
- * @final
- *
  * @author Sam Rapaport <me@samrapdev.com>
  */
 final class MockClientStrategy implements DiscoveryStrategy

--- a/src/Strategy/MockClientStrategy.php
+++ b/src/Strategy/MockClientStrategy.php
@@ -2,6 +2,7 @@
 
 namespace Http\Discovery\Strategy;
 
+use Http\Client\HttpClient;
 use Http\Mock\Client as Mock;
 
 /**
@@ -16,7 +17,7 @@ final class MockClientStrategy implements DiscoveryStrategy
      */
     public static function getCandidates($type)
     {
-        return ($type === 'Http\Client\HttpClient')
+        return ($type === HttpClient::class)
             ? ['class' => Mock::class, 'condition' => Mock::class]
             : [];
     }

--- a/src/Strategy/MockClientStrategy.php
+++ b/src/Strategy/MockClientStrategy.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Http\Discovery\Strategy;
+
+use Http\Mock\Client as Mock;
+
+/**
+ * Find the Mock client.
+ *
+ * @internal
+ * @final
+ *
+ * @author Sam Rapaport <me@samrapdev.com>
+ */
+final class MockClientStrategy implements DiscoveryStrategy
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getCandidates($type)
+    {
+        return ($type === 'Http\Client\HttpClient')
+            ? ['class' => Mock::class, 'condition' => Mock::class]
+            : [];
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    |yes|
| BC breaks?      | no|
| Deprecations?   | no|
| Related tickets | mentioned in #89 
| Documentation   | https://github.com/php-http/documentation/pull/173
| License         | MIT


#### What's in this PR?

Please see #89 for a full description of this PR.

Essentially, we need a way to test DI within our tests which in many cases cannot be fully implemented without having some way to discover the Mock Client. This new class allows us to add the `MockClientStrategy` to the `HttpClientDiscovery`'s strategies as shown in @Nyholm 's example in the above mentioned PR.

#### Example Usage

``` php
use ThirdPartyService

class ThirdPartyServiceTest extends PHPUnit_Framework_TestCase
{
    public function setUpBeforeClass()
    {
        HttpClientDiscovery::prependStrategy(MockClientStrategy::class);
    }

    public function setUp()
    {
        $this->service = new ThirdPartyService;
    }
}
```


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix)
