### PR TITLE
Fix mock client strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Unreleased
 
+- MockClientStategy class fixed
+
 ## 1.2.0 - 2017-02-12
 
 ### Added

--- a/spec/Strategy/MockClientStrategySpec.php
+++ b/spec/Strategy/MockClientStrategySpec.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace spec\Http\Discovery\Strategy;
+
+use Http\Client\HttpClient;
+use Http\Discovery\ClassDiscovery;
+use Http\Discovery\Strategy\DiscoveryStrategy;
+use Http\Discovery\Strategy;
+use PhpSpec\ObjectBehavior;
+use spec\Http\Discovery\Helper\DiscoveryHelper;
+
+class MockClientStrategySpec extends ObjectBehavior
+{
+    function let()
+    {
+        ClassDiscovery::setStrategies([Strategy\MockClientStrategy::class]);
+    }
+
+    function it_should_return_the_mock_client(DiscoveryStrategy $strategy)
+    {
+        $candidates = $this->getCandidates(HttpClient::class);
+        $candidates->shouldBeArray();
+        $candidates->shouldHaveCount(1);
+    }
+}

--- a/src/Strategy/MockClientStrategy.php
+++ b/src/Strategy/MockClientStrategy.php
@@ -18,7 +18,7 @@ final class MockClientStrategy implements DiscoveryStrategy
     public static function getCandidates($type)
     {
         return ($type === HttpClient::class)
-            ? ['class' => Mock::class, 'condition' => Mock::class]
+            ? [['class' => Mock::class, 'condition' => Mock::class]]
             : [];
     }
 }


### PR DESCRIPTION
| Q               | A|
| --------------- | ---|
| Bug fix?        | yes
| New feature?    | no|
| BC breaks?      | no|
| Deprecations?   | no|
| Related tickets | -| 
| Documentation   | -|
| License         | MIT

#### What's in this PR?

- The Strategy returned a invalid array earlier.

>The return value is always an array with zero or more elements.
>Each  element is an array with two keys
>['class' => string, 'condition' => mixed]

<detail><summary>The older value would lead to `Illegal string offset 'class'` error:</summary>

```
Illegal string offset 'class'

/vendor/php-http/discovery/src/ClassDiscovery.php:70
/vendor/php-http/discovery/src/HttpClientDiscovery.php:25
/src/php/Client.php:22
/tests/ClientTest.php:18
```
</detail>

#### Why?

Mock Client Stategy Discovery is broken without this fix.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)

#### To Do

- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here

I'm not used to phpspec, so I'm not sure if the spec suffices here, or what can be done to improve it. I attempted using HttpClientDiscovery with the strategy set to mock, but that required adding too many dependencies.