### PR TITLE
add plugin client factory discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,14 @@
     "require": {
         "php": "^5.5 || ^7.0"
     },
+    "repositories": {
+        "client-common": {
+            "type": "vcs",
+            "url": "git@github.com:fbourigault/client-common"
+        }
+    },
     "require-dev": {
+        "php-http/client-common": "dev-plugin-client-factory",
         "php-http/httplug": "^1.0",
         "php-http/message-factory": "^1.0",
         "puli/composer-plugin": "1.0.0-beta10",

--- a/spec/PluginClientFactoryDiscoverySpec.php
+++ b/spec/PluginClientFactoryDiscoverySpec.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace spec\Http\Discovery;
+
+use Http\Client\Common\PluginClientFactoryInterface;
+use Http\Discovery\ClassDiscovery;
+use Http\Discovery\NotFoundException;
+use Http\Discovery\Strategy\DiscoveryStrategy;
+use PhpSpec\ObjectBehavior;
+use spec\Http\Discovery\Helper\DiscoveryHelper;
+
+class PluginClientFactoryDiscoverySpec extends ObjectBehavior
+{
+    function let()
+    {
+        ClassDiscovery::setStrategies([DiscoveryHelper::class]);
+        DiscoveryHelper::clearClasses();
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Http\Discovery\PluginClientFactoryDiscovery');
+    }
+
+    function it_is_a_class_discovery()
+    {
+        $this->shouldHaveType('Http\Discovery\ClassDiscovery');
+    }
+
+    function it_finds_a_plugin_client_factory(DiscoveryStrategy $strategy) {
+
+        $candidate = ['class' => 'spec\Http\Discovery\Stub\PluginClientFactoryStub', 'condition' => true];
+        DiscoveryHelper::setClasses(PluginClientFactoryInterface::class, [$candidate]);
+
+        $this->find()->shouldImplement('Http\Client\Common\PluginClientFactoryInterface');
+    }
+
+    function it_throw_exception(DiscoveryStrategy $strategy) {
+        $this->shouldThrow(NotFoundException::class)->duringFind();
+    }
+}

--- a/spec/Stub/PluginClientFactoryStub.php
+++ b/spec/Stub/PluginClientFactoryStub.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace spec\Http\Discovery\Stub;
+
+use Http\Client\Common\PluginClientFactoryInterface;
+
+class PluginClientFactoryStub implements PluginClientFactoryInterface
+{
+    public function createClient($client, array $plugins = [], array $options = [])
+    {
+
+    }
+}

--- a/src/PluginClientFactoryDiscovery.php
+++ b/src/PluginClientFactoryDiscovery.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Http\Discovery;
+
+use Http\Client\Common\PluginClientFactoryInterface;
+use Http\Discovery\Exception\DiscoveryFailedException;
+
+/**
+ * Finds a PluginClientFactoryInterface implementation.
+ *
+ * @author Fabien Bourigault <bourigaultfabien@gmail.com>
+ */
+final class PluginClientFactoryDiscovery extends ClassDiscovery
+{
+    /**
+     * Finds a PluginClientFactoryInterface implementation.
+     *
+     * @return PluginClientFactoryInterface
+     *
+     * @throws Exception\NotFoundException
+     */
+    public static function find()
+    {
+        try {
+            $client = static::findOneByType(PluginClientFactoryInterface::class);
+        } catch (DiscoveryFailedException $e) {
+            throw new NotFoundException(
+                'No HTTPlug plugin clients found. Make sure to install "php-http/client-common".',
+                0,
+                $e
+            );
+        }
+
+        return static::instantiateClass($client);
+    }
+}

--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -3,6 +3,7 @@
 namespace Http\Discovery\Strategy;
 
 use GuzzleHttp\Psr7\Request as GuzzleRequest;
+use Http\Client\Common\PluginClientFactory;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 use Http\Message\StreamFactory\GuzzleStreamFactory;
 use Http\Message\UriFactory\GuzzleUriFactory;
@@ -59,6 +60,9 @@ final class CommonClassesStrategy implements DiscoveryStrategy
             ['class' => Socket::class, 'condition' => Socket::class],
             ['class' => Buzz::class, 'condition' => Buzz::class],
             ['class' => React::class, 'condition' => React::class],
+        ],
+        'Http\Client\Common\PluginClientFactoryInterface' => [
+            ['class' => PluginClientFactory::class, 'condition' => PluginClientFactory::class],
         ],
     ];
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially https://github.com/php-http/HttplugBundle/issues/109
| Documentation   | TODO
| License         | MIT

This is required to display plugins created by 3rd party libraries in the HttplugBundle profiler. See https://github.com/php-http/HttplugBundle/issues/109#issuecomment-300461535 for all puzzle pieces.

### To Do

- [ ] Update the changelog.
- [ ] Use a stable php-http/client-common release which include https://github.com/php-http/client-common/pull/71.
- [ ] Update the documentation.