### PR TITLE
Add support for discovering CakePHP Adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+### Added
+
+- Discovery support for CakePHP adapter
 
 ## 1.2.1 - 2017-03-02
 

--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -20,6 +20,7 @@ use Http\Client\Curl\Client as Curl;
 use Http\Client\Socket\Client as Socket;
 use Http\Adapter\React\Client as React;
 use Http\Adapter\Buzz\Client as Buzz;
+use Http\Adapter\Cake\Client as Cake;
 
 /**
  * @internal
@@ -59,6 +60,7 @@ final class CommonClassesStrategy implements DiscoveryStrategy
             ['class' => Socket::class, 'condition' => Socket::class],
             ['class' => Buzz::class, 'condition' => Buzz::class],
             ['class' => React::class, 'condition' => React::class],
+            ['class' => Cake::class, 'condition' => Cake::class],
         ],
     ];
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a/
| Documentation   | https://github.com/php-http/documentation/pull/209
| License         | MIT


#### What's in this PR?

This PR adds support for discovering the CakePHP Adapter.


#### Checklist

- [x] Updated CHANGELOG.md to describe new feature
- [x] Documentation pull request created (if not simply a bugfix)