### PR TITLE
Use ::class constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+### Changed
+
+- Use ::class constant instead of writing the class string. 
+
 ## 1.3.0 - 2017-08-03
 
 ### Added

--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -54,6 +54,7 @@ abstract class ClassDiscovery
                 $candidates = call_user_func($strategy.'::getCandidates', $type);
             } catch (StrategyUnavailableException $e) {
                 $exceptions[] = $e;
+
                 continue;
             }
 

--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -3,8 +3,13 @@
 namespace Http\Discovery\Strategy;
 
 use GuzzleHttp\Psr7\Request as GuzzleRequest;
+use Http\Client\HttpAsyncClient;
+use Http\Client\HttpClient;
+use Http\Message\MessageFactory;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Http\Message\StreamFactory;
 use Http\Message\StreamFactory\GuzzleStreamFactory;
+use Http\Message\UriFactory;
 use Http\Message\UriFactory\GuzzleUriFactory;
 use Http\Message\MessageFactory\DiactorosMessageFactory;
 use Http\Message\StreamFactory\DiactorosStreamFactory;
@@ -35,27 +40,27 @@ final class CommonClassesStrategy implements DiscoveryStrategy
      * @var array
      */
     private static $classes = [
-        'Http\Message\MessageFactory' => [
+        MessageFactory::class => [
             ['class' => GuzzleMessageFactory::class, 'condition' => [GuzzleRequest::class, GuzzleMessageFactory::class]],
             ['class' => DiactorosMessageFactory::class, 'condition' => [DiactorosRequest::class, DiactorosMessageFactory::class]],
             ['class' => SlimMessageFactory::class, 'condition' => [SlimRequest::class, SlimMessageFactory::class]],
         ],
-        'Http\Message\StreamFactory' => [
+        StreamFactory::class => [
             ['class' => GuzzleStreamFactory::class, 'condition' => [GuzzleRequest::class, GuzzleStreamFactory::class]],
             ['class' => DiactorosStreamFactory::class, 'condition' => [DiactorosRequest::class, DiactorosStreamFactory::class]],
             ['class' => SlimStreamFactory::class, 'condition' => [SlimRequest::class, SlimStreamFactory::class]],
         ],
-        'Http\Message\UriFactory' => [
+        UriFactory::class => [
             ['class' => GuzzleUriFactory::class, 'condition' => [GuzzleRequest::class, GuzzleUriFactory::class]],
             ['class' => DiactorosUriFactory::class, 'condition' => [DiactorosRequest::class, DiactorosUriFactory::class]],
             ['class' => SlimUriFactory::class, 'condition' => [SlimRequest::class, SlimUriFactory::class]],
         ],
-        'Http\Client\HttpAsyncClient' => [
+        HttpAsyncClient::class => [
             ['class' => Guzzle6::class, 'condition' => Guzzle6::class],
             ['class' => Curl::class, 'condition' => Curl::class],
             ['class' => React::class, 'condition' => React::class],
         ],
-        'Http\Client\HttpClient' => [
+        HttpClient::class => [
             ['class' => Guzzle6::class, 'condition' => Guzzle6::class],
             ['class' => Guzzle5::class, 'condition' => Guzzle5::class],
             ['class' => Curl::class, 'condition' => Curl::class],


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

Using ::class constants for all class expressions


#### Why?

Im working with [php-scoper](https://github.com/humbug/php-scoper). It rewrites all namespaces with a prefix. Since we are using a simple string (not a class) php-scoper has no change of rewriting this. 