### PR TITLE
Added missing dependency nyholm/psr7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.4.1 - 2018-03-8
+
+- Added missing dependency nyholm/psr7
+
 ## 1.4.0 - 2018-02-06
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "php-http/message-factory": "^1.0",
         "puli/composer-plugin": "1.0.0-beta10",
         "phpspec/phpspec": "^2.4",
-        "henrikbjorn/phpspec-code-coverage" : "^2.0.2"
+        "henrikbjorn/phpspec-code-coverage" : "^2.0.2",
+        "nyholm/psr7": "^0.3"
     },
     "suggest": {
         "puli/composer-plugin": "Sets up Puli which is recommended for Discovery to work. Check http://docs.php-http.org/en/latest/discovery.html for more details.",


### PR DESCRIPTION
…n/mailgun-php/issues/452

| Q               | A
| --------------- | ---
| Bug fix?        | **yes**
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/mailgun/mailgun-php/issues/452
| Documentation   | 
| License         | MIT


#### What's in this PR?

Require missing dependency for v1.4.0


#### Why?

Nyholm/psr4 source files are not downloaded after a composer install, but are being used by this package. This results in multiple errors, including the error explained in https://github.com/mailgun/mailgun-php/issues/452


#### Example Usage


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] Create a new version 1.4.1 so that all dependants of this package get the right version and will not encounter the problems of this bug.
