### PR TITLE
Stop condition evaluation on first failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@
 
 - Support for `nyholm/psr7` version 1.0. 
 
-## 1.4.1 - 2018-09-20
-
 ### Fixed
 
 - Fixed condition evaluation

--- a/spec/ClassDiscoverySpec.php
+++ b/spec/ClassDiscoverySpec.php
@@ -44,9 +44,13 @@ class ClassDiscoverySpec extends ObjectBehavior
 
     function it_validates_conditions() {
         $c0 = ['class' => 'ClassName0', 'condition' => false];
+        $c0b = ['class' => 'ClassName0', 'condition' => [false, true]];
+        $c0c = ['class' => 'ClassName0', 'condition' => [true, false]];
+        $c0d = ['class' => 'ClassName0', 'condition' => [true, false, true]];
         $c1 = ['class' => 'ClassName1', 'condition' => true];
         $c2 = ['class' => 'ClassName2', 'condition' => false];
-        DiscoveryHelper::setClasses('Foobar', [$c0, $c1, $c2]);
+        $c3 = ['class' => 'ClassName3', 'condition' => true];
+        DiscoveryHelper::setClasses('Foobar', [$c0, $c0b, $c0c, $c0d, $c1, $c2, $c3]);
 
         $this->find('Foobar')->shouldReturn('ClassName1');
     }

--- a/spec/ClassDiscoverySpec.php
+++ b/spec/ClassDiscoverySpec.php
@@ -47,10 +47,13 @@ class ClassDiscoverySpec extends ObjectBehavior
         $c0b = ['class' => 'ClassName0', 'condition' => [false, true]];
         $c0c = ['class' => 'ClassName0', 'condition' => [true, false]];
         $c0d = ['class' => 'ClassName0', 'condition' => [true, false, true]];
+        $c0e = ['class' => 'ClassName0', 'condition' => [false, function() {
+            throw new \RuntimeException('This should never be called');
+        }]];
         $c1 = ['class' => 'ClassName1', 'condition' => true];
         $c2 = ['class' => 'ClassName2', 'condition' => false];
         $c3 = ['class' => 'ClassName3', 'condition' => true];
-        DiscoveryHelper::setClasses('Foobar', [$c0, $c0b, $c0c, $c0d, $c1, $c2, $c3]);
+        DiscoveryHelper::setClasses('Foobar', [$c0, $c0b, $c0c, $c0d, $c0e, $c1, $c2, $c3]);
 
         $this->find('Foobar')->shouldReturn('ClassName1');
     }

--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -167,7 +167,6 @@ abstract class ClassDiscovery
         } elseif (is_bool($condition)) {
             return $condition;
         } elseif (is_array($condition)) {
-
             // Immediately stop execution if the condition is false
             for ($i = 0; $i < count($condition); ++$i) {
                 if (false === static::evaluateCondition($condition[$i])) {

--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -171,7 +171,7 @@ abstract class ClassDiscovery
 
             // Immediately stop execution if the condition is false
             for ($i = 0; $i < count($condition) && false !== $evaluatedCondition; ++$i) {
-                $evaluatedCondition &= static::evaluateCondition($condition[$i]);
+                $evaluatedCondition = $evaluatedCondition && static::evaluateCondition($condition[$i]);
             }
 
             return $evaluatedCondition;

--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -163,18 +163,19 @@ abstract class ClassDiscovery
             // Should be extended for functions, extensions???
             return class_exists($condition);
         } elseif (is_callable($condition)) {
-            return (bool) $condition();
+            return $condition();
         } elseif (is_bool($condition)) {
             return $condition;
         } elseif (is_array($condition)) {
-            $evaluatedCondition = true;
 
             // Immediately stop execution if the condition is false
-            for ($i = 0; $i < count($condition) && false !== $evaluatedCondition; ++$i) {
-                $evaluatedCondition = $evaluatedCondition && static::evaluateCondition($condition[$i]);
+            for ($i = 0; $i < count($condition); ++$i) {
+                if (false === static::evaluateCondition($condition[$i])) {
+                    return false;
+                }
             }
 
-            return (bool) $evaluatedCondition;
+            return true;
         }
 
         return false;

--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -163,7 +163,7 @@ abstract class ClassDiscovery
             // Should be extended for functions, extensions???
             return class_exists($condition);
         } elseif (is_callable($condition)) {
-            return $condition();
+            return (bool) $condition();
         } elseif (is_bool($condition)) {
             return $condition;
         } elseif (is_array($condition)) {
@@ -174,7 +174,7 @@ abstract class ClassDiscovery
                 $evaluatedCondition = $evaluatedCondition && static::evaluateCondition($condition[$i]);
             }
 
-            return $evaluatedCondition;
+            return (bool) $evaluatedCondition;
         }
 
         return false;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation
| License         | MIT


#### What's in this PR?

The `&=` operator will convert the value to an integer (see some examples here: https://stackoverflow.com/questions/17553004/boolean-assignment-operators-in-php) which causes the condition evaluation to not stop on the first failure, as otherwise noted.


#### Why?

Discovery for a specific adapter should not continue if any condition fails.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
