### PR TITLE
simplify discovery code

### DIFF
--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -162,14 +162,17 @@ abstract class ClassDiscovery
         if (is_string($condition)) {
             // Should be extended for functions, extensions???
             return self::safeClassExists($condition);
-        } elseif (is_callable($condition)) {
-            return $condition();
-        } elseif (is_bool($condition)) {
+        }
+        if (is_callable($condition)) {
+            return (bool) $condition();
+        }
+        if (is_bool($condition)) {
             return $condition;
-        } elseif (is_array($condition)) {
-            // Immediately stop execution if the condition is false
-            for ($i = 0; $i < count($condition); ++$i) {
-                if (false === static::evaluateCondition($condition[$i])) {
+        }
+        if (is_array($condition)) {
+            foreach ($condition as $c) {
+                if (false === static::evaluateCondition($c)) {
+                    // Immediately stop execution if the condition is false
                     return false;
                 }
             }


### PR DESCRIPTION
avoid unnecessary elseif to reduce complexity.
use foreach instead of for loop.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | follow-up to #112
| Documentation   | -
| License         | MIT


#### What's in this PR?

Avoid unnecessary elseif. Use foreach to not fail if list of conditions is a hashmap and not a 0-based numerical array.

#### Why?

Reduce complexity.
