### PR TITLE
Better exception message when we do not find candidates

### DIFF
--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -4,6 +4,7 @@ namespace Http\Discovery;
 
 use Http\Discovery\Exception\ClassInstantiationFailedException;
 use Http\Discovery\Exception\DiscoveryFailedException;
+use Http\Discovery\Exception\NoCandidateFoundException;
 use Http\Discovery\Exception\StrategyUnavailableException;
 
 /**
@@ -70,6 +71,8 @@ abstract class ClassDiscovery
 
                 return $candidate['class'];
             }
+
+            $exceptions[] = new NoCandidateFoundException($strategy, $candidates);
         }
 
         throw DiscoveryFailedException::create($exceptions);

--- a/src/Exception/NoCandidateFoundException.php
+++ b/src/Exception/NoCandidateFoundException.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Http\Discovery\Exception;
+
+use Http\Discovery\Exception;
+
+/**
+ * When we have used a strategy but no candidates provided by that strategy could be used.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+final class NoCandidateFoundException extends \Exception implements Exception
+{
+    /**
+     * @param string $strategy
+     * @param array  $candidates
+     */
+    public function __construct($strategy, array $candidates)
+    {
+        $classes = array_map(
+            function ($a) {
+                return $a['class'];
+            },
+            $candidates
+        );
+
+        $message = sprintf(
+            'No valid candidate found using strategy "%s". We tested the following candidates: %s.',
+            $strategy,
+            implode(', ', $classes)
+        );
+
+        parent::__construct($message);
+    }
+}


### PR DESCRIPTION
This changes the error message from:

<img width="900" alt="screenshot 2018-12-29 at 10 26 31" src="https://user-images.githubusercontent.com/1275206/50536407-628bd380-0b54-11e9-8b62-cb863b674d72.png">


To: 

<img width="902" alt="screenshot 2018-12-29 at 10 26 17" src="https://user-images.githubusercontent.com/1275206/50536412-66b7f100-0b54-11e9-805e-ca003074dced.png">

I want to highlight that is not only Puli that causes that no candidate is found. 