### PR TITLE
Added a discovery of classes considered as deprecated

### DIFF
--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -24,6 +24,7 @@ abstract class ClassDiscovery
     private static $strategies = [
         Strategy\PuliBetaStrategy::class,
         Strategy\CommonClassesStrategy::class,
+        Strategy\DeprecatedClassesStrategy::class,
     ];
 
     /**

--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -29,7 +29,6 @@ use Http\Adapter\Buzz\Client as Buzz;
 use Http\Adapter\Cake\Client as Cake;
 use Http\Adapter\Zend\Client as Zend;
 use Http\Adapter\Artax\Client as Artax;
-use Nyholm\Psr7\Request as NyholmRequest;
 use Nyholm\Psr7\Factory\HttplugFactory as NyholmHttplugFactory;
 
 /**
@@ -54,7 +53,6 @@ final class CommonClassesStrategy implements DiscoveryStrategy
             ['class' => GuzzleStreamFactory::class, 'condition' => [GuzzleRequest::class, GuzzleStreamFactory::class]],
             ['class' => DiactorosStreamFactory::class, 'condition' => [DiactorosRequest::class, DiactorosStreamFactory::class]],
             ['class' => SlimStreamFactory::class, 'condition' => [SlimRequest::class, SlimStreamFactory::class]],
-            ['class' => NyholmStreamFactory::class, 'condition' => [NyholmRequest::class, NyholmStreamFactory::class]],
         ],
         UriFactory::class => [
             ['class' => NyholmHttplugFactory::class, 'condition' => [NyholmHttplugFactory::class]],

--- a/src/Strategy/DeprecatedClassesStrategy.php
+++ b/src/Strategy/DeprecatedClassesStrategy.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Http\Discovery\Strategy;
+
+use Http\Message\MessageFactory;
+use Http\Message\StreamFactory;
+use Http\Message\UriFactory;
+use Nyholm\Psr7\Factory\MessageFactory as NyholmMessageFactory;
+use Nyholm\Psr7\Factory\StreamFactory as NyholmStreamFactory;
+use Nyholm\Psr7\Factory\UriFactory as NyholmUriFactory;
+
+/**
+ * Discover classes that are deprecated and no longer should be supported.
+ *
+ * @internal
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+final class DeprecatedClassesStrategy implements DiscoveryStrategy
+{
+    private static $classes = [
+        MessageFactory::class => [
+            ['class' => NyholmMessageFactory::class, 'condition' => [NyholmRequest::class, NyholmMessageFactory::class]],
+        ],
+        StreamFactory::class => [
+            ['class' => NyholmStreamFactory::class, 'condition' => [NyholmRequest::class, NyholmStreamFactory::class]],
+        ],
+        UriFactory::class => [
+            ['class' => NyholmUriFactory::class, 'condition' => [NyholmRequest::class, NyholmUriFactory::class]],
+        ],
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getCandidates($type)
+    {
+        if (isset(self::$classes[$type])) {
+            return self::$classes[$type];
+        }
+
+        return [];
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   |
| License         | MIT

According to our [BC promise](https://php-http.readthedocs.io/en/latest/httplug/backwards-compatibility.html#discovery) we can never remove previously discovered classes. 

In our current master we have removed support for nyholm/psr7:0.3.0. Im not sure nobody will notice that we break BC here. But I think we should care.

That is why I added a new strategy, just like `CommonClassesStrategy` but for "deprecated" or removed classes. 