### PR TITLE
Removed PHP7 code

### DIFF
--- a/src/Exception/NoCandidateFoundException.php
+++ b/src/Exception/NoCandidateFoundException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Http\Discovery\Exception;
 
 use Http\Discovery\Exception;


### PR DESCRIPTION
Oops, I made a mistake. 

This happened because we never instantiate this class. 