### PR TITLE
Fixed PHPDoc return type in Psr17FactoryDiscovery

### DIFF
--- a/src/Psr17FactoryDiscovery.php
+++ b/src/Psr17FactoryDiscovery.php
@@ -43,7 +43,7 @@ final class Psr17FactoryDiscovery extends ClassDiscovery
     }
 
     /**
-     * @return RequestFactoryInterface
+     * @return ResponseFactoryInterface
      *
      * @throws Exception\NotFoundException
      */


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

This pull request only fix return type in PHPDoc of findResponseFactory of Psr17FactoryDiscovery


#### Why?

Any problem. Just my IDE that is going crazy :)


#### Example Usage


#### Checklist


#### To Do

