### PR TITLE
Fix the Mock strategy to work for async clients too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unrelesed
+
+- Fix MockClientStrategy for provide the mock as an async client too
+
 ## 1.6.0 - 2019-01-23
 
 ### Added

--- a/spec/Strategy/MockClientStrategySpec.php
+++ b/spec/Strategy/MockClientStrategySpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Http\Discovery\Strategy;
 
+use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\Discovery\ClassDiscovery;
 use Http\Discovery\Strategy\DiscoveryStrategy;
@@ -19,6 +20,13 @@ class MockClientStrategySpec extends ObjectBehavior
     function it_should_return_the_mock_client(DiscoveryStrategy $strategy)
     {
         $candidates = $this->getCandidates(HttpClient::class);
+        $candidates->shouldBeArray();
+        $candidates->shouldHaveCount(1);
+    }
+
+    function it_should_return_the_mock_client_as_async(DiscoveryStrategy $strategy)
+    {
+        $candidates = $this->getCandidates(HttpAsyncClient::class);
         $candidates->shouldBeArray();
         $candidates->shouldHaveCount(1);
     }

--- a/src/Strategy/MockClientStrategy.php
+++ b/src/Strategy/MockClientStrategy.php
@@ -2,6 +2,7 @@
 
 namespace Http\Discovery\Strategy;
 
+use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\Mock\Client as Mock;
 
@@ -17,8 +18,12 @@ final class MockClientStrategy implements DiscoveryStrategy
      */
     public static function getCandidates($type)
     {
-        return (HttpClient::class === $type)
-            ? [['class' => Mock::class, 'condition' => Mock::class]]
-            : [];
+        switch ($type) {
+            case HttpClient::class:
+            case HttpAsyncClient::class:
+                return [['class' => Mock::class, 'condition' => Mock::class]];
+            default:
+                return [];
+       }
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT


#### What's in this PR?

This PR makes the Mock client discoverable as an async client too.

#### Why?

I need it in https://github.com/getsentry/sentry-php/pull/777 to avoid using a real client while testing the autodiscovery process.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)
