### PR TITLE
PSR-17 should be available to use Symfony's HttplugClient

### DIFF
--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -8,6 +8,7 @@ use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\Discovery\MessageFactoryDiscovery;
 use Http\Discovery\Psr17FactoryDiscovery;
+use Psr\Http\Message\RequestFactoryInterface as Psr17RequestFactory;
 use Http\Message\MessageFactory;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 use Http\Message\StreamFactory;
@@ -72,7 +73,7 @@ final class CommonClassesStrategy implements DiscoveryStrategy
             ['class' => React::class, 'condition' => React::class],
         ],
         HttpClient::class => [
-            ['class' => SymfonyHttplug::class, 'condition' => SymfonyHttplug::class],
+            ['class' => SymfonyHttplug::class, 'condition' => [SymfonyHttplug::class, Psr17RequestFactory::class]],
             ['class' => Guzzle6::class, 'condition' => Guzzle6::class],
             ['class' => Guzzle5::class, 'condition' => Guzzle5::class],
             ['class' => Curl::class, 'condition' => Curl::class],


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #149
| Documentation   | N/A
| License         | MIT


#### What's in this PR?

This is a bit of a stab in the dark, but I ran into the same problem in that issue and it seems like this PR should fix it.

Since #141 Symfony's `Symfony\Component\HttpClient\HttplugClient` is the first client class attempted when using auto-discovery, with its only condition being that that specific class is available (which is true if you have `symfony/http-client >=4.4` installed).  However, if you don't have anything which satisfies the PSR-17 auto discovery installed, then auto-discovery as a whole is going to fail because the Symfony class can't be instantiated.

This PR attempts to fix the issue by adding a condition on the PSR-17 interfaces being present as well.  Looking at the Symfony app where I ran into the problem (Symfony 3.4 with the HttpClient component being pulled in as a transient dependency at 4.4), it seems like this would fix the problem because through that application's transient dependencies PSR-17 isn't installed so this condition should fail and it fall through to a working client (Guzzle in this application's case).


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] Is this the right way to address this issue?
