### PR TITLE
Allow a condition to specify an interface and not just classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 
-## 1.7.1 - 2019-12-17
+## 1.7.2 - 2019-12-27
+
+### Fixed
+
+- Allow a condition to specify an interface and not just classes.
+
+## 1.7.1 - 2019-12-26
 
 ### Fixed
 

--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -228,7 +228,7 @@ abstract class ClassDiscovery
     public static function safeClassExists($class)
     {
         try {
-            return class_exists($class);
+            return class_exists($class) || interface_exists($class);
         } catch (\Exception $e) {
             return false;
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT

We previously introduced "conditions" that specify interfaces. But we never made sure they could be evaluated to true.  