### PR TITLE
Alternative to Symfony Httplug Async

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,9 +66,9 @@ matrix:
               # We should be able to find a client when Symfony is only partly installed and we have guzzle adapter installed
               - install_test will-find "Http\Discovery\HttpClientDiscovery::find();" "symfony/http-client:5.* php-http/guzzle6-adapter php-http/httplug php-http/message-factory guzzlehttp/psr7:1.*"
               # Test that we find a client with Symfony and Guzzle
-              - install_test will-find "Http\Discovery\HttpClientDiscovery::find();" "php-http/client-common:2.* php-http/message:1.8* symfony/http-client:4.* php-http/guzzle6-adapter"
+              - install_test will-find "Http\Discovery\HttpClientDiscovery::find();" "php-http/client-common:2.* php-http/message:1.8.* symfony/http-client:4.* php-http/guzzle6-adapter"
               # Test that we find an async client with Symfony and Guzzle
-              - install_test will-find "Http\Discovery\HttpAsyncClientDiscovery::find();" "php-http/client-common:2.* php-http/message:1.8* symfony/http-client:4.* php-http/guzzle6-adapter"
+              - install_test will-find "Http\Discovery\HttpAsyncClientDiscovery::find();" "php-http/client-common:2.* php-http/message:1.8.* symfony/http-client:4.* php-http/guzzle6-adapter"
 
 before_install:
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,10 @@ matrix:
               - install_test cant-find "Http\Discovery\HttpClientDiscovery::find();" "symfony/http-client:5.* php-http/httplug guzzlehttp/psr7:1.* http-interop/http-factory-guzzle"
               # We should be able to find a client when Symfony is only partly installed and we have guzzle adapter installed
               - install_test will-find "Http\Discovery\HttpClientDiscovery::find();" "symfony/http-client:5.* php-http/guzzle6-adapter php-http/httplug php-http/message-factory guzzlehttp/psr7:1.*"
-
+              # Test that we find a client with Symfony and Guzzle
+              - install_test will-find "Http\Discovery\HttpClientDiscovery::find();" "php-http/client-common:2.* php-http/message:1.8* symfony/http-client:4.* php-http/guzzle6-adapter"
+              # Test that we find an async client with Symfony and Guzzle
+              - install_test will-find "Http\Discovery\HttpAsyncClientDiscovery::find();" "php-http/client-common:2.* php-http/message:1.8* symfony/http-client:4.* php-http/guzzle6-adapter"
 
 before_install:
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi

--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -228,7 +228,7 @@ abstract class ClassDiscovery
     public static function safeClassExists($class)
     {
         try {
-            return class_exists($class);
+            return class_exists($class) || interface_exists($class);
         } catch (\Exception $e) {
             return false;
         }

--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -228,7 +228,7 @@ abstract class ClassDiscovery
     public static function safeClassExists($class)
     {
         try {
-            return class_exists($class) || interface_exists($class);
+            return class_exists($class);
         } catch (\Exception $e) {
             return false;
         }

--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -69,13 +69,13 @@ final class CommonClassesStrategy implements DiscoveryStrategy
             ['class' => SlimUriFactory::class, 'condition' => [SlimRequest::class, SlimUriFactory::class]],
         ],
         HttpAsyncClient::class => [
-            ['class' => SymfonyHttplug::class, 'condition' => [SymfonyHttplug::class, Promise::class, RequestFactory::class, [CommonClassesStrategy::class, 'isPsr17FactoryInstalled']]],
+            ['class' => SymfonyHttplug::class, 'condition' => [SymfonyHttplug::class, Promise::class, RequestFactory::class, [self::class, 'isPsr17FactoryInstalled']]],
             ['class' => Guzzle6::class, 'condition' => Guzzle6::class],
             ['class' => Curl::class, 'condition' => Curl::class],
             ['class' => React::class, 'condition' => React::class],
         ],
         HttpClient::class => [
-            ['class' => SymfonyHttplug::class, 'condition' => [SymfonyHttplug::class, RequestFactory::class, [CommonClassesStrategy::class, 'isPsr17FactoryInstalled']]],
+            ['class' => SymfonyHttplug::class, 'condition' => [SymfonyHttplug::class, RequestFactory::class, [self::class, 'isPsr17FactoryInstalled']]],
             ['class' => Guzzle6::class, 'condition' => Guzzle6::class],
             ['class' => Guzzle5::class, 'condition' => Guzzle5::class],
             ['class' => Curl::class, 'condition' => Curl::class],
@@ -139,6 +139,7 @@ final class CommonClassesStrategy implements DiscoveryStrategy
 
     /**
      * Can be used as a condition.
+     *
      * @return bool
      */
     public static function isPsr17FactoryInstalled()

--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Psr7\Request as GuzzleRequest;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
+use Http\Discovery\Exception\NotFoundException;
 use Http\Discovery\MessageFactoryDiscovery;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Message\RequestFactory;
@@ -68,13 +69,13 @@ final class CommonClassesStrategy implements DiscoveryStrategy
             ['class' => SlimUriFactory::class, 'condition' => [SlimRequest::class, SlimUriFactory::class]],
         ],
         HttpAsyncClient::class => [
-            ['class' => SymfonyHttplug::class, 'condition' => [SymfonyHttplug::class, Promise::class, RequestFactory::class]],
+            ['class' => SymfonyHttplug::class, 'condition' => [SymfonyHttplug::class, Promise::class, RequestFactory::class, [CommonClassesStrategy::class, 'isPsr17FactoryInstalled']]],
             ['class' => Guzzle6::class, 'condition' => Guzzle6::class],
             ['class' => Curl::class, 'condition' => Curl::class],
             ['class' => React::class, 'condition' => React::class],
         ],
         HttpClient::class => [
-            ['class' => SymfonyHttplug::class, 'condition' => [SymfonyHttplug::class, RequestFactory::class, Psr17RequestFactory::class]],
+            ['class' => SymfonyHttplug::class, 'condition' => [SymfonyHttplug::class, RequestFactory::class, [CommonClassesStrategy::class, 'isPsr17FactoryInstalled']]],
             ['class' => Guzzle6::class, 'condition' => Guzzle6::class],
             ['class' => Guzzle5::class, 'condition' => Guzzle5::class],
             ['class' => Curl::class, 'condition' => Curl::class],
@@ -134,5 +135,20 @@ final class CommonClassesStrategy implements DiscoveryStrategy
     public static function symfonyPsr18Instantiate()
     {
         return new SymfonyPsr18(null, Psr17FactoryDiscovery::findResponseFactory(), Psr17FactoryDiscovery::findStreamFactory());
+    }
+
+    /**
+     * Can be use as a condition.
+     * @return bool
+     */
+    public static function isPsr17FactoryInstalled()
+    {
+        try {
+            Psr17FactoryDiscovery::findResponseFactory();
+        } catch (NotFoundException $e) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -138,7 +138,7 @@ final class CommonClassesStrategy implements DiscoveryStrategy
     }
 
     /**
-     * Can be use as a condition.
+     * Can be used as a condition.
      * @return bool
      */
     public static function isPsr17FactoryInstalled()
@@ -146,6 +146,10 @@ final class CommonClassesStrategy implements DiscoveryStrategy
         try {
             Psr17FactoryDiscovery::findResponseFactory();
         } catch (NotFoundException $e) {
+            return false;
+        } catch (\Throwable $e) {
+            trigger_error('Trying to find a PSR-17 ResponseFactory when an exception got thrown: '.$e->getMessage(), E_USER_ERROR);
+
             return false;
         }
 

--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -149,7 +149,7 @@ final class CommonClassesStrategy implements DiscoveryStrategy
         } catch (NotFoundException $e) {
             return false;
         } catch (\Throwable $e) {
-            trigger_error('Trying to find a PSR-17 ResponseFactory when an exception got thrown: '.$e->getMessage(), E_USER_ERROR);
+            trigger_error(sprintf('Got exception "%s (%s)" while checking if a PSR-17 ResponseFactory is available', get_class($e), $e->getMessage()), E_USER_WARNING);
 
             return false;
         }


### PR DESCRIPTION
This is a alternative to #159 

Im not sure which one I like better. 

This will check if a PSR17Factory can be found before accepting Symfony's HttplugClient as a candidate. 