### PR TITLE
Support discovering PSR-17 factories from guzzlehttp/psr7 package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Change Log
 
+## Unreleased
+
+### Added
+
+- Support discovering PSR-17 factories of `guzzlehttp/psr7` package
+
 ## 1.7.4 - 2020-01-03
 
 ### Fixed
 
-- Improve conditions on Symfony's async HTTPlug client. 
+- Improve conditions on Symfony's async HTTPlug client.
 
 ## 1.7.3 - 2019-12-27
 

--- a/src/Strategy/CommonPsr17ClassesStrategy.php
+++ b/src/Strategy/CommonPsr17ClassesStrategy.php
@@ -23,6 +23,7 @@ final class CommonPsr17ClassesStrategy implements DiscoveryStrategy
         RequestFactoryInterface::class => [
             'Nyholm\Psr7\Factory\Psr17Factory',
             'Zend\Diactoros\RequestFactory',
+            'GuzzleHttp\Psr7\HttpFactory',
             'Http\Factory\Diactoros\RequestFactory',
             'Http\Factory\Guzzle\RequestFactory',
             'Http\Factory\Slim\RequestFactory',
@@ -30,6 +31,7 @@ final class CommonPsr17ClassesStrategy implements DiscoveryStrategy
         ResponseFactoryInterface::class => [
             'Nyholm\Psr7\Factory\Psr17Factory',
             'Zend\Diactoros\ResponseFactory',
+            'GuzzleHttp\Psr7\HttpFactory',
             'Http\Factory\Diactoros\ResponseFactory',
             'Http\Factory\Guzzle\ResponseFactory',
             'Http\Factory\Slim\ResponseFactory',
@@ -37,6 +39,7 @@ final class CommonPsr17ClassesStrategy implements DiscoveryStrategy
         ServerRequestFactoryInterface::class => [
             'Nyholm\Psr7\Factory\Psr17Factory',
             'Zend\Diactoros\ServerRequestFactory',
+            'GuzzleHttp\Psr7\HttpFactory',
             'Http\Factory\Diactoros\ServerRequestFactory',
             'Http\Factory\Guzzle\ServerRequestFactory',
             'Http\Factory\Slim\ServerRequestFactory',
@@ -44,6 +47,7 @@ final class CommonPsr17ClassesStrategy implements DiscoveryStrategy
         StreamFactoryInterface::class => [
             'Nyholm\Psr7\Factory\Psr17Factory',
             'Zend\Diactoros\StreamFactory',
+            'GuzzleHttp\Psr7\HttpFactory',
             'Http\Factory\Diactoros\StreamFactory',
             'Http\Factory\Guzzle\StreamFactory',
             'Http\Factory\Slim\StreamFactory',
@@ -51,6 +55,7 @@ final class CommonPsr17ClassesStrategy implements DiscoveryStrategy
         UploadedFileFactoryInterface::class => [
             'Nyholm\Psr7\Factory\Psr17Factory',
             'Zend\Diactoros\UploadedFileFactory',
+            'GuzzleHttp\Psr7\HttpFactory',
             'Http\Factory\Diactoros\UploadedFileFactory',
             'Http\Factory\Guzzle\UploadedFileFactory',
             'Http\Factory\Slim\UploadedFileFactory',
@@ -58,6 +63,7 @@ final class CommonPsr17ClassesStrategy implements DiscoveryStrategy
         UriFactoryInterface::class => [
             'Nyholm\Psr7\Factory\Psr17Factory',
             'Zend\Diactoros\UriFactory',
+            'GuzzleHttp\Psr7\HttpFactory',
             'Http\Factory\Diactoros\UriFactory',
             'Http\Factory\Guzzle\UriFactory',
             'Http\Factory\Slim\UriFactory',


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | it depends on the outcome of the discussion
| Deprecations?   | no
| Related tickets | fixes #164
| License         | MIT


#### What's in this PR?

In the next version of [`guzzlehttp/psr7`](https://github.com/guzzle/psr7) there will be support for PSR-17 (actually the feature has not been released yet), so I simply added support for discovering the factories.


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix


#### To Do

For the moment I added the new factories in the middle of the list instead of at the end. What this means is that suddenly the priorities of discovery will change and the `guzzle/psr7` package will be preferred over the `php-http/guzzle6-adapter`, which may be considered a BC. Just let me know if I have to move the classes to the end of the list instead