### PR TITLE
Avoid triggering Symfony HTTPlug Client exception

### DIFF
--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -112,10 +112,12 @@ final class CommonClassesStrategy implements DiscoveryStrategy
 
             // HTTPlug 2.0 clients implements PSR18Client too.
             foreach (self::$classes[HttpClient::class] as $c) {
-                // Attempting to load the Symfony HTTPlug client will throw an
-                // exception if the necessary dependencies are not installed.
-                if (SymfonyHttplug::class !== $c['class'] && is_subclass_of($c['class'], Psr18Client::class)) {
-                    $candidates[] = $c;
+                try {
+                    if (is_subclass_of($c['class'], Psr18Client::class)) {
+                        $candidates[] = $c;
+                    }
+                } catch (\Throwable $e) {
+                    trigger_error(sprintf('Got exception "%s (%s)" while checking if a PSR-18 Client is available', get_class($e), $e->getMessage()), E_USER_WARNING);
                 }
             }
 

--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -112,7 +112,9 @@ final class CommonClassesStrategy implements DiscoveryStrategy
 
             // HTTPlug 2.0 clients implements PSR18Client too.
             foreach (self::$classes[HttpClient::class] as $c) {
-                if (is_subclass_of($c['class'], Psr18Client::class)) {
+                // Attempting to load the Symfony HTTPlug client will throw an
+                // exception if the necessary dependencies are not installed.
+                if (SymfonyHttplug::class !== $c['class'] && is_subclass_of($c['class'], Psr18Client::class)) {
                     $candidates[] = $c;
                 }
             }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes|
| New feature?    | no|
| BC breaks?      | no|
| Deprecations?   | no|
| Related tickets | resolves #171  |
| Documentation   | N/A |
| License         | MIT |


#### What's in this PR?

This PR prevents the following `LogicException` from being triggered if you attempt to use `Psr18ClientDiscovery::find()` when the "php-http/httplug" package is not installed.

```
PHP Fatal error:  Uncaught LogicException: You cannot use "Symfony\Component\HttpClient\HttplugClient" as the "php-http/httplug" package is not installed. Try running "composer require php-http/httplug". in /Users/matt/code/discovery-repro/vendor/symfony/http-client/HttplugClient.php:44
Stack trace:
#0 /Users/matt/code/discovery-repro/vendor/composer/ClassLoader.php(444): include()
#1 /Users/matt/code/discovery-repro/vendor/composer/ClassLoader.php(322): Composer\Autoload\includeFile('/Users/matt/cod...')
#2 [internal function]: Composer\Autoload\ClassLoader->loadClass('Symfony\\Compone...')
#3 [internal function]: spl_autoload_call('Symfony\\Compone...')
#4 /Users/matt/code/discovery-repro/vendor/php-http/discovery/src/Strategy/CommonClassesStrategy.php(115): is_subclass_of('Symfony\\Compone...', 'Psr\\Http\\Client...')
#5 [internal function]: Http\Discovery\Strategy\CommonClassesStrategy::getCandidates('Psr\\Http\\Client...')
#6 /Users/matt/code/discovery-repro/vendor/php-http/discovery/src/ClassDiscovery.php(56): call_user_ in /Users/matt/code/discovery-repro/vendor/symfony/http-client/HttplugClient.php on line 44
```

#### Why?

When the `Symfony\Component\HttpClient\HttplugClient` class is loaded [Symfony checks if the `Http\Client\HttpClient` interface exists](https://github.com/symfony/http-client/blob/ff12d3fb19fd1b3f4961320d5648de172fab3976/HttplugClient.php#L43). If it doesn't exist an exception is thrown.

When discovering a PSR-18 client the `CommonClassesStrategy` [calls `is_subclass_of` on the `Symfony\Component\HttpClient\HttplugClient`](https://github.com/php-http/discovery/blob/82dbef649ccffd8e4f22e1953c3a5265992b83c0/src/Strategy/CommonClassesStrategy.php#L115), which triggers the exception.

We don't need to call `is_subclass_of` on the Symfony Httplug client because we know it doesn't implement the PSR-18 interface, so we can just avoid calling it, thus avoiding the exception.

There might be a more elegant way to solve this. Let me know if you would prefer an alternative solution.

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)
