### PR TITLE
Add method to retrieve currently configured strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Support discovering PSR-17 factories of `guzzlehttp/psr7` package
 - Support discovering PSR-17 factories of `laminas/laminas-diactoros` pakcage
+- `ClassDiscovery::getStrategies()` to retrieve the list of current strategies.
 
 ## 1.7.4 - 2020-01-03
 

--- a/spec/ClassDiscoverySpec.php
+++ b/spec/ClassDiscoverySpec.php
@@ -68,6 +68,11 @@ class ClassDiscoverySpec extends ObjectBehavior
         $this->find('Foobar')->shouldReturn('Added');
     }
 
+    function it_retrieves_configured_strategies() {
+        $expect = [DiscoveryHelper::class];
+        $this->getStrategies()->shouldReturn($expect);
+    }
+
     function it_appends_strategies() {
         $candidate = ['class' => 'Added'];
         DiscoveryHelper::setClasses('Foobar', [$candidate]);

--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -125,11 +125,11 @@ abstract class ClassDiscovery
     }
 
     /**
-     * Returns the currently configured discovery strategies as fully qualified class names
+     * Returns the currently configured discovery strategies as fully qualified class names.
      *
      * @return string[]
      */
-    public static function getStrategies() : iterable
+    public static function getStrategies(): iterable
     {
         return self::$strategies;
     }

--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -125,6 +125,16 @@ abstract class ClassDiscovery
     }
 
     /**
+     * Returns the currently configured discovery strategies as fully qualified class names
+     *
+     * @return string[]
+     */
+    public static function getStrategies() : iterable
+    {
+        return self::$strategies;
+    }
+
+    /**
      * Append a strategy at the end of the strategy queue.
      *
      * @param string $strategy Fully qualified class name to a DiscoveryStrategy


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | yes
| BC breaks?      | no|yes
| Deprecations?   | no|yes
| Related tickets | none
| Documentation   | Will supply if appropriate/acceptable feature
| License         | MIT


#### What's in this PR?

Adds a method to retrieve the currently configured discovery strategies.


#### Why?

When testing a consumer, it is useful to clear strategies to simulate a Not Found Exception, i.e. `Psr18ClientDiscovery::setStrategies([])'` but in order to reinstate the default behaviour of the lib after doing this, strategies would need to be duplicated in consumer tests.

#### Example Usage

``` php

$currentStrategies = Psr18ClientDiscovery::getStrategies();
Psr18ClientDiscovery::setStrategies([]);
try {
  // Test my thing…
  $this->fail('An exception was not thrown');
} catch (ExpectedError $error) {
  $this->makeMoreAssertions();
} finally {
  Psr18ClientDiscovery::setStrategies($currentStrategies);
}
```


#### Checklist

- [x] Updated CHANGELOG.md to describe new feature
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [x] Tests… Sorry, I'm not familiar with phpspec but would be happy to write a unit tests??
