### PR TITLE
Fixing typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Added
 
 - Support discovering PSR-17 factories of `guzzlehttp/psr7` package
-- Support discovering PSR-17 factories of `laminas/laminas-diactoros` pakcage
+- Support discovering PSR-17 factories of `laminas/laminas-diactoros` package
 - `ClassDiscovery::getStrategies()` to retrieve the list of current strategies.
 
 ### Fixed


### PR DESCRIPTION
#### What's in this PR?

I've added a typo in #169. This typo found its way to master and to the release notes.

#### To Do

- [ ] Release author should also rename release notes for https://github.com/php-http/discovery/releases/tag/1.8.0
