### PR TITLE
Re-enable code coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,12 @@ branches:
 matrix:
     fast_finish: true
     include:
-        - name: PHPSpec code coverage
+        - name: PHPSpec
           php: 7.1
-            # Disable code coverage until https://github.com/leanphp/phpspec-code-coverage/pull/38 is released
-            # DEPENDENCIES="leanphp/phpspec-code-coverage:^4.2" TEST_COMMAND="composer test-ci"
-          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test" PULI_VERSION=1.0.0-beta9
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" TEST_COMMAND="composer test" PULI_VERSION=1.0.0-beta9
+        - name: PHPSpec code coverage
+          php: 7.2
+          env: COVERAGE=true TEST_COMMAND="composer test-ci" PULI_VERSION=1.0.0-beta10 DEPENDENCIES="friends-of-phpspec/phpspec-code-coverage:^4.3"
         - name: PHPUnit tests
           php: 7.3
           env: TEST_COMMAND="./vendor/bin/phpunit" DEPENDENCIES="phpunit/phpunit:^7.5 nyholm/psr7:^1.0 kriswallsmith/buzz:^1.0 php-http/curl-client:^1.0 php-http/message"

--- a/phpspec.ci.yml
+++ b/phpspec.ci.yml
@@ -5,7 +5,7 @@ suites:
 formatter.name: pretty
 bootstrap: spec/autoload.php
 extensions:
-    LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension: ~
+    FriendsOfPhpSpec\PhpSpec\CodeCoverage\CodeCoverageExtension: ~
     Akeneo\SkipExampleExtension: ~
 code_coverage:
     format: clover


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Code coverage reporting was commented out in the travis file due to needing PHPSpec support. This is provided by a replacement package. This PR is basically the same as https://github.com/php-http/client-common/pull/195, which was merged earlier today. ;)