### PR TITLE
Fixed typo in method name

### DIFF
--- a/src/Psr17FactoryDiscovery.php
+++ b/src/Psr17FactoryDiscovery.php
@@ -111,7 +111,7 @@ final class Psr17FactoryDiscovery extends ClassDiscovery
      *
      * @throws Exception\NotFoundException
      */
-    public static function findUrlFactory()
+    public static function findUriFactory()
     {
         try {
             $messageFactory = static::findOneByType(UriFactoryInterface::class);
@@ -120,5 +120,17 @@ final class Psr17FactoryDiscovery extends ClassDiscovery
         }
 
         return static::instantiateClass($messageFactory);
+    }
+
+    /**
+     * @return UriFactoryInterface
+     *
+     * @throws Exception\NotFoundException
+     *
+     * @deprecated This will be removed in 2.0. Consider using the findUrlFactory() method.
+     */
+    public static function findUrlFactory()
+    {
+        return static::findUriFactory();
     }
 }

--- a/tests/Psr17FactoryDiscoveryTest.php
+++ b/tests/Psr17FactoryDiscoveryTest.php
@@ -42,6 +42,7 @@ class Psr17FactoryDiscoveryTest extends TestCase
         yield ['findServerRequestFactory', ServerRequestFactoryInterface::class];
         yield ['findStreamFactory', StreamFactoryInterface::class];
         yield ['findUploadedFileFactory', UploadedFileFactoryInterface::class];
+        yield ['findUriFactory', UriFactoryInterface::class];
         yield ['findUrlFactory', UriFactoryInterface::class];
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| License         | MIT

URI Discovery was replaced by PSR-17 discovery, but the method was named incorrectly. It returns a `UriFactoryInterface`. Moreover, the old discovery class was also `Uri`, so the previous new name is not only wrong, but also not consistent.