### PR TITLE
add phalcon psr supported

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -7,8 +7,7 @@ finder:
         - "src"
         - "tests"
 
-enabled:
-    - short_array_syntax
-
 disabled:
     - phpdoc_annotation_without_dot # This is still buggy: https://github.com/symfony/symfony/pull/19198
+    - single_line_class_definition
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,8 @@ matrix:
                     local fold=$(date +%s%N)
                     echo -e "travis_fold:start:$fold"
                     echo -e "\\e[1;34m$title\\e[0m"
-                    echo "./tests/install.sh \"$1\" \"$2\" \"$3\""
-                    ./tests/install.sh "$1" "$2" "$3" 2>&1
+                    echo "./tests/install.sh \"$1\" \"$2\" \"$3\" \"$4\""
+                    ./tests/install.sh "$1" "$2" "$3" "$4" 2>&1
                     local ok=$?
                     (exit $ok) &&
                         echo -e "\\e[32mOK\\e[0m $title\\n\\ntravis_fold:end:$fold" ||
@@ -88,6 +88,8 @@ matrix:
               - install_test will-find "Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();" "http-interop/http-factory-guzzle:1.*"
               # Test that we find PSR-17 nyholm
               - install_test will-find "Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();" "nyholm/psr7:^1.3"
+              # Test that we find Phalcon with PSR
+              - install_test will-find "Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();" "" "psr-1.0.0 phalcon-4.0.6"
 
 before_install:
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi

--- a/src/Exception/NoCandidateFoundException.php
+++ b/src/Exception/NoCandidateFoundException.php
@@ -13,7 +13,6 @@ final class NoCandidateFoundException extends \Exception implements Exception
 {
     /**
      * @param string $strategy
-     * @param array  $candidates
      */
     public function __construct($strategy, array $candidates)
     {

--- a/src/Strategy/CommonPsr17ClassesStrategy.php
+++ b/src/Strategy/CommonPsr17ClassesStrategy.php
@@ -21,6 +21,7 @@ final class CommonPsr17ClassesStrategy implements DiscoveryStrategy
      */
     private static $classes = [
         RequestFactoryInterface::class => [
+            'Phalcon\Http\Message\RequestFactory',
             'Nyholm\Psr7\Factory\Psr17Factory',
             'Zend\Diactoros\RequestFactory',
             'GuzzleHttp\Psr7\HttpFactory',
@@ -30,6 +31,7 @@ final class CommonPsr17ClassesStrategy implements DiscoveryStrategy
             'Laminas\Diactoros\RequestFactory',
         ],
         ResponseFactoryInterface::class => [
+            'Phalcon\Http\Message\ResponseFactory',
             'Nyholm\Psr7\Factory\Psr17Factory',
             'Zend\Diactoros\ResponseFactory',
             'GuzzleHttp\Psr7\HttpFactory',
@@ -39,6 +41,7 @@ final class CommonPsr17ClassesStrategy implements DiscoveryStrategy
             'Laminas\Diactoros\ResponseFactory',
         ],
         ServerRequestFactoryInterface::class => [
+            'Phalcon\Http\Message\ServerRequestFactory',
             'Nyholm\Psr7\Factory\Psr17Factory',
             'Zend\Diactoros\ServerRequestFactory',
             'GuzzleHttp\Psr7\HttpFactory',
@@ -48,6 +51,7 @@ final class CommonPsr17ClassesStrategy implements DiscoveryStrategy
             'Laminas\Diactoros\ServerRequestFactory',
         ],
         StreamFactoryInterface::class => [
+            'Phalcon\Http\Message\StreamFactory',
             'Nyholm\Psr7\Factory\Psr17Factory',
             'Zend\Diactoros\StreamFactory',
             'GuzzleHttp\Psr7\HttpFactory',
@@ -57,6 +61,7 @@ final class CommonPsr17ClassesStrategy implements DiscoveryStrategy
             'Laminas\Diactoros\StreamFactory',
         ],
         UploadedFileFactoryInterface::class => [
+            'Phalcon\Http\Message\UploadedFileFactory',
             'Nyholm\Psr7\Factory\Psr17Factory',
             'Zend\Diactoros\UploadedFileFactory',
             'GuzzleHttp\Psr7\HttpFactory',
@@ -66,6 +71,7 @@ final class CommonPsr17ClassesStrategy implements DiscoveryStrategy
             'Laminas\Diactoros\UploadedFileFactory',
         ],
         UriFactoryInterface::class => [
+            'Phalcon\Http\Message\UriFactory',
             'Nyholm\Psr7\Factory\Psr17Factory',
             'Zend\Diactoros\UriFactory',
             'GuzzleHttp\Psr7\HttpFactory',

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -28,6 +28,7 @@ fi
 # Arg 4 means some pecl things will be install
 if ! [ -z "$4" ]; then
     pecl install $4
+    pwd
 fi
 
 # Copy the current version of php-http/discovery

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -20,7 +20,7 @@ mkdir -p $BUILD_DIR
 composer init --working-dir $BUILD_DIR --no-interaction
 composer req --working-dir $BUILD_DIR php-http/discovery --no-update
 
-# Define packages from arguments
+# Argument 3 installs additional composer packages
 if ! [ -z "$3" ]; then
     composer req --working-dir $BUILD_DIR $3
 fi

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -21,7 +21,14 @@ composer init --working-dir $BUILD_DIR --no-interaction
 composer req --working-dir $BUILD_DIR php-http/discovery --no-update
 
 # Define packages from arguments
-composer req --working-dir $BUILD_DIR $3
+if [ $3 -ne ""]; then
+    composer req --working-dir $BUILD_DIR $3
+fi
+
+# Arg 4 means some pecl things will be install
+if [ $4 -ne ""]; then
+    pecl install $4
+fi
 
 # Copy the current version of php-http/discovery
 cp -R src $BUILD_DIR/vendor/php-http/discovery

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -21,12 +21,12 @@ composer init --working-dir $BUILD_DIR --no-interaction
 composer req --working-dir $BUILD_DIR php-http/discovery --no-update
 
 # Define packages from arguments
-if [ $3 -ne ""]; then
+if ! [ -z "$3" ]; then
     composer req --working-dir $BUILD_DIR $3
 fi
 
 # Arg 4 means some pecl things will be install
-if [ $4 -ne ""]; then
+if ! [ -z "$4" ]; then
     pecl install $4
 fi
 

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -29,15 +29,14 @@ fi
 cp -R src $BUILD_DIR/vendor/php-http/discovery
 cd $BUILD_DIR
 
+# Arg 4 means some pecl things will be install
+if ! [ -z "$4" ]; then
+    pecl install $4 > /dev/null
+fi
+
 # Run PHP and check exit code
 php -r "require 'vendor/autoload.php'; ${2}" > /dev/null
 PHP_EXIT_CODE=$?
-
-
-# Arg 4 means some pecl things will be install
-if ! [ -z "$4" ]; then
-    pecl install $4
-fi
 
 # Print result
 echo ""

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -23,6 +23,8 @@ composer req --working-dir $BUILD_DIR php-http/discovery --no-update
 # Argument 3 installs additional composer packages
 if ! [ -z "$3" ]; then
     composer req --working-dir $BUILD_DIR $3
+else
+    composer req --working-dir $BUILD_DIR
 fi
 
 # Copy the current version of php-http/discovery

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -18,25 +18,19 @@ mkdir -p $BUILD_DIR
 
 # Init composer
 composer init --working-dir $BUILD_DIR --no-interaction
-
 composer req --working-dir $BUILD_DIR php-http/discovery --no-update
 
 # Argument 3 installs additional composer packages
-if ! [ -z "$3" ]; then
-    composer req --working-dir $BUILD_DIR $3
-else
-    # composer req --no-update impiles --no install
-    composer req --working-dir $BUILD_DIR
+composer req --working-dir $BUILD_DIR $3
+
+# Arg 4 means some pecl things will be install
+if ! [ -z "$4" ]; then
+    pecl install $4
 fi
 
 # Copy the current version of php-http/discovery
 cp -R src $BUILD_DIR/vendor/php-http/discovery
 cd $BUILD_DIR
-
-# Arg 4 means some pecl things will be install
-if ! [ -z "$4" ]; then
-    pecl install $4 > /dev/null
-fi
 
 # Run PHP and check exit code
 php -r "require 'vendor/autoload.php'; ${2}" > /dev/null

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -18,7 +18,6 @@ mkdir -p $BUILD_DIR
 
 # Init composer
 composer init --working-dir $BUILD_DIR --no-interaction
-composer req --working-dir $BUILD_DIR php-http/discovery --no-update
 
 # Argument 3 installs additional composer packages
 if ! [ -z "$3" ]; then
@@ -29,6 +28,8 @@ fi
 if ! [ -z "$4" ]; then
     pecl install $4
 fi
+
+composer req --working-dir $BUILD_DIR php-http/discovery --no-update
 
 # Copy the current version of php-http/discovery
 ls -al

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -28,10 +28,11 @@ fi
 # Arg 4 means some pecl things will be install
 if ! [ -z "$4" ]; then
     pecl install $4
-    pwd
 fi
 
 # Copy the current version of php-http/discovery
+ls -al
+ls -al $BUILD_DIR
 cp -R src $BUILD_DIR/vendor/php-http/discovery
 cd $BUILD_DIR
 

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -18,12 +18,14 @@ mkdir -p $BUILD_DIR
 
 # Init composer
 composer init --working-dir $BUILD_DIR --no-interaction
+
 composer req --working-dir $BUILD_DIR php-http/discovery --no-update
 
 # Argument 3 installs additional composer packages
 if ! [ -z "$3" ]; then
     composer req --working-dir $BUILD_DIR $3
 else
+    # composer req --no-update impiles --no install
     composer req --working-dir $BUILD_DIR
 fi
 

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -18,28 +18,26 @@ mkdir -p $BUILD_DIR
 
 # Init composer
 composer init --working-dir $BUILD_DIR --no-interaction
+composer req --working-dir $BUILD_DIR php-http/discovery --no-update
 
 # Argument 3 installs additional composer packages
 if ! [ -z "$3" ]; then
     composer req --working-dir $BUILD_DIR $3
 fi
 
-# Arg 4 means some pecl things will be install
-if ! [ -z "$4" ]; then
-    pecl install $4
-fi
-
-composer req --working-dir $BUILD_DIR php-http/discovery --no-update
-
 # Copy the current version of php-http/discovery
-ls -al
-ls -al $BUILD_DIR
 cp -R src $BUILD_DIR/vendor/php-http/discovery
 cd $BUILD_DIR
 
 # Run PHP and check exit code
 php -r "require 'vendor/autoload.php'; ${2}" > /dev/null
 PHP_EXIT_CODE=$?
+
+
+# Arg 4 means some pecl things will be install
+if ! [ -z "$4" ]; then
+    pecl install $4
+fi
 
 # Print result
 echo ""


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| Documentation   | none
| License         | MIT


#### What's in this PR?

Add `Phalcon\Http\Message\*Factory` to `src/Strategy/CommonPsr17ClassesStrategy.php`

#### Why?

Cause when I use sentry in phalcon 4.0, they said some factory not found, but phalcon has those factories.

#### Example Usage

nothing changes

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)

#### To Do

- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
