### PR TITLE
Add Guzzle7 Adapter Client Discovery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,8 @@ matrix:
               - install_test will-find "Http\Discovery\HttpClientDiscovery::find();" "php-http/guzzle6-adapter:^1.1.1"
               # Test that we find Guzzle 6 v2
               - install_test will-find "Http\Discovery\HttpClientDiscovery::find();" "php-http/guzzle6-adapter:^2.0.1"
+              # Test that we find Guzzle 7 Adapter
+              - install_test will-find "Http\Discovery\HttpClientDiscovery::find();" "php-http/guzzle7-adapter:^0.1"
               # Test that we find a client with Symfony and Guzzle PSR-7
               - install_test will-find "Http\Discovery\HttpClientDiscovery::find();" "symfony/http-client:5.* php-http/httplug php-http/message-factory guzzlehttp/psr7:1.* http-interop/http-factory-guzzle"
               # We should fail if we dont have php-http/message-factory or PSR-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Support discovering HttpClient of `php-http/guzzle7-adapter` https://github.com/php-http/discovery/pull/189
+
 ## 1.11.0 - 2020-09-22
 
 - Use correct method name to find Uri Factory in PSR17 https://github.com/php-http/discovery/pull/181

--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -27,6 +27,7 @@ use Http\Message\StreamFactory\SlimStreamFactory;
 use Http\Message\UriFactory\SlimUriFactory;
 use Slim\Http\Request as SlimRequest;
 use GuzzleHttp\Client as GuzzleHttp;
+use Http\Adapter\Guzzle7\Client as Guzzle7;
 use Http\Adapter\Guzzle6\Client as Guzzle6;
 use Http\Adapter\Guzzle5\Client as Guzzle5;
 use Http\Client\Curl\Client as Curl;
@@ -71,12 +72,14 @@ final class CommonClassesStrategy implements DiscoveryStrategy
         ],
         HttpAsyncClient::class => [
             ['class' => SymfonyHttplug::class, 'condition' => [SymfonyHttplug::class, Promise::class, RequestFactory::class, [self::class, 'isPsr17FactoryInstalled']]],
+            ['class' => Guzzle7::class, 'condition' => Guzzle7::class],           
             ['class' => Guzzle6::class, 'condition' => Guzzle6::class],
             ['class' => Curl::class, 'condition' => Curl::class],
             ['class' => React::class, 'condition' => React::class],
         ],
         HttpClient::class => [
             ['class' => SymfonyHttplug::class, 'condition' => [SymfonyHttplug::class, RequestFactory::class, [self::class, 'isPsr17FactoryInstalled']]],
+            ['class' => Guzzle7::class, 'condition' => Guzzle7::class],
             ['class' => Guzzle6::class, 'condition' => Guzzle6::class],
             ['class' => Guzzle5::class, 'condition' => Guzzle5::class],
             ['class' => Curl::class, 'condition' => Curl::class],

--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -72,7 +72,7 @@ final class CommonClassesStrategy implements DiscoveryStrategy
         ],
         HttpAsyncClient::class => [
             ['class' => SymfonyHttplug::class, 'condition' => [SymfonyHttplug::class, Promise::class, RequestFactory::class, [self::class, 'isPsr17FactoryInstalled']]],
-            ['class' => Guzzle7::class, 'condition' => Guzzle7::class],           
+            ['class' => Guzzle7::class, 'condition' => Guzzle7::class],
             ['class' => Guzzle6::class, 'condition' => Guzzle6::class],
             ['class' => Curl::class, 'condition' => Curl::class],
             ['class' => React::class, 'condition' => React::class],


### PR DESCRIPTION
Related: 

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/php-http/guzzle6-adapter/pull/72
| Documentation   | Adds support for https://github.com/php-http/guzzle7-adapter
| License         | MIT


#### What's in this PR?

Adds support for https://github.com/php-http/guzzle7-adapter


#### Why?

To provide  the HttpClient for Guzzle7


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix


