### PR TITLE
Do not suggest installation of puli via composer or error messages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "puli/composer-plugin": "1.0.0-beta10"
     },
     "suggest": {
-        "puli/composer-plugin": "Sets up Puli which is recommended for Discovery to work. Check http://docs.php-http.org/en/latest/discovery.html for more details.",
         "php-http/message": "Allow to use Guzzle, Diactoros or Slim Framework factories"
     },
     "autoload": {

--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -22,9 +22,9 @@ abstract class ClassDiscovery
      * @var array
      */
     private static $strategies = [
-        Strategy\PuliBetaStrategy::class,
         Strategy\CommonClassesStrategy::class,
         Strategy\CommonPsr17ClassesStrategy::class,
+        Strategy\PuliBetaStrategy::class,
     ];
 
     private static $deprecatedStrategies = [

--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -27,6 +27,10 @@ abstract class ClassDiscovery
         Strategy\CommonPsr17ClassesStrategy::class,
     ];
 
+    private static $deprecatedStrategies = [
+        Strategy\PuliBetaStrategy::class => true,
+    ];
+
     /**
      * Discovery cache to make the second time we use discovery faster.
      *
@@ -55,7 +59,9 @@ abstract class ClassDiscovery
             try {
                 $candidates = call_user_func($strategy.'::getCandidates', $type);
             } catch (StrategyUnavailableException $e) {
-                $exceptions[] = $e;
+                if (!isset(self::$deprecatedStrategies[$strategy])) {
+                    $exceptions[] = $e;
+                }
 
                 continue;
             }

--- a/tests/Exception/InitializeExceptionTest.php
+++ b/tests/Exception/InitializeExceptionTest.php
@@ -11,7 +11,6 @@ class InitializeExceptionTest extends TestCase
     {
         $e[] = new DiscoveryException\ClassInstantiationFailedException();
         $e[] = new DiscoveryException\NotFoundException();
-        $e[] = new DiscoveryException\PuliUnavailableException();
         $e[] = new DiscoveryException\StrategyUnavailableException();
         $e[] = new DiscoveryException\NoCandidateFoundException('CommonClasses', []);
         $e[] = DiscoveryException\DiscoveryFailedException::create($e);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

Puli has not been modified in 5 years, it's abandoned, the website is down and it's not compatible with Composer v2, it should be removed from this project.

More urgently it is currently the first suggestion for why discovery may not work, leading novice users to install puli to fix this error message, which just makes things worse.

So this PR for now just removes the suggestion from composer.json and the error message.

Next step would be proper full deprecation and eventually removal.

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix)

