### PR TITLE
Add request alias specific to the Laminas namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.14.1 - TBC
+
+- [#199](https://github.com/php-http/discovery/pull/199) - Fixes message factory discovery for `laminas-diactoros ^2.7` 
+
 ## 1.14.0 - 2021-06-21
 
 - Deprecate puli as it has been unmaintained for a long time and is not compatible with composer 2 https://github.com/php-http/discovery/pull/195

--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -21,7 +21,8 @@ use Http\Message\MessageFactory\DiactorosMessageFactory;
 use Http\Message\StreamFactory\DiactorosStreamFactory;
 use Http\Message\UriFactory\DiactorosUriFactory;
 use Psr\Http\Client\ClientInterface as Psr18Client;
-use Zend\Diactoros\Request as DiactorosRequest;
+use Zend\Diactoros\Request as ZendDiactorosRequest;
+use Laminas\Diactoros\Request as DiactorosRequest;
 use Http\Message\MessageFactory\SlimMessageFactory;
 use Http\Message\StreamFactory\SlimStreamFactory;
 use Http\Message\UriFactory\SlimUriFactory;
@@ -55,18 +56,21 @@ final class CommonClassesStrategy implements DiscoveryStrategy
         MessageFactory::class => [
             ['class' => NyholmHttplugFactory::class, 'condition' => [NyholmHttplugFactory::class]],
             ['class' => GuzzleMessageFactory::class, 'condition' => [GuzzleRequest::class, GuzzleMessageFactory::class]],
+            ['class' => DiactorosMessageFactory::class, 'condition' => [ZendDiactorosRequest::class, DiactorosMessageFactory::class]],
             ['class' => DiactorosMessageFactory::class, 'condition' => [DiactorosRequest::class, DiactorosMessageFactory::class]],
             ['class' => SlimMessageFactory::class, 'condition' => [SlimRequest::class, SlimMessageFactory::class]],
         ],
         StreamFactory::class => [
             ['class' => NyholmHttplugFactory::class, 'condition' => [NyholmHttplugFactory::class]],
             ['class' => GuzzleStreamFactory::class, 'condition' => [GuzzleRequest::class, GuzzleStreamFactory::class]],
+            ['class' => DiactorosStreamFactory::class, 'condition' => [ZendDiactorosRequest::class, DiactorosStreamFactory::class]],
             ['class' => DiactorosStreamFactory::class, 'condition' => [DiactorosRequest::class, DiactorosStreamFactory::class]],
             ['class' => SlimStreamFactory::class, 'condition' => [SlimRequest::class, SlimStreamFactory::class]],
         ],
         UriFactory::class => [
             ['class' => NyholmHttplugFactory::class, 'condition' => [NyholmHttplugFactory::class]],
             ['class' => GuzzleUriFactory::class, 'condition' => [GuzzleRequest::class, GuzzleUriFactory::class]],
+            ['class' => DiactorosUriFactory::class, 'condition' => [ZendDiactorosRequest::class, DiactorosUriFactory::class]],
             ['class' => DiactorosUriFactory::class, 'condition' => [DiactorosRequest::class, DiactorosUriFactory::class]],
             ['class' => SlimUriFactory::class, 'condition' => [SlimRequest::class, SlimUriFactory::class]],
         ],


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| Related tickets | fixes #198
| License         | MIT


#### What's in this PR?

Since [laminas-diactoros 2.7.0](https://github.com/laminas/laminas-diactoros/releases/tag/2.7.0) - it appears that Message Factory discovery fails _(When the deprecated `MessageFactoryDiscovery` class is used)_

Pretty sure that this is down to the removal of [laminas-zendframework-bridge](https://github.com/laminas/laminas-zendframework-bridge) in that release.

#### To reproduce

```shell
composer require php-http/discovery
composer require laminas/laminas-diactoros ^2.7
composer require php-http/message-factory
```

And then run a php script along the lines of:

```php
<?php
require 'vendor/autoload.php';

use Http\Discovery\MessageFactoryDiscovery;
$factory = MessageFactoryDiscovery::find();

```

This should yield a DiscoveryFailed exception.

Apologies, but I'm not sure how to go about writing tests for this scenario…

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix

