### PR TITLE
symfony httplug adapter needs php-http httplug to be installed

### DIFF
--- a/src/Psr18ClientDiscovery.php
+++ b/src/Psr18ClientDiscovery.php
@@ -24,7 +24,7 @@ final class Psr18ClientDiscovery extends ClassDiscovery
         try {
             $client = static::findOneByType(ClientInterface::class);
         } catch (DiscoveryFailedException $e) {
-            throw new \Http\Discovery\Exception\NotFoundException('No PSR-18 clients found. Make sure to install a package providing "psr/http-client-implementation". Example: "php-http/guzzle6-adapter".', 0, $e);
+            throw new \Http\Discovery\Exception\NotFoundException('No PSR-18 clients found. Make sure to install a package providing "psr/http-client-implementation". Example: "php-http/guzzle7-adapter".', 0, $e);
         }
 
         return static::instantiateClass($client);

--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -17,6 +17,7 @@ use Http\Client\Curl\Client as Curl;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\Client\Socket\Client as Socket;
+use Http\Discovery\ClassDiscovery;
 use Http\Discovery\Exception\NotFoundException;
 use Http\Discovery\MessageFactoryDiscovery;
 use Http\Discovery\Psr17FactoryDiscovery;
@@ -136,8 +137,11 @@ final class CommonClassesStrategy implements DiscoveryStrategy
 
         // HTTPlug 2.0 clients implements PSR18Client too.
         foreach (self::$classes[HttpClient::class] as $c) {
+            if (!is_string($c['class'])) {
+                continue;
+            }
             try {
-                if (is_subclass_of($c['class'], Psr18Client::class)) {
+                if (ClassDiscovery::safeClassExists($c['class']) && is_subclass_of($c['class'], Psr18Client::class)) {
                     $candidates[] = $c;
                 }
             } catch (\Throwable $e) {


### PR DESCRIPTION
if we don't check for the httplug client interface, we trigger a warning:
https://github.com/symfony/http-client/blob/290eb481973b4984eb59377585f6afbc65a0f645/HttplugClient.php#L44

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #201
| Documentation   | -
| License         | MIT


#### What's in this PR?

avoid having symfony trigger a warning when symfony httplug client is not usable due to missing dependencies.