### PR TITLE
[POC] HTTP client options

### DIFF
--- a/src/ClassDiscovery.php
+++ b/src/ClassDiscovery.php
@@ -230,6 +230,33 @@ abstract class ClassDiscovery
     }
 
     /**
+     * Get an instance of the $class.
+     *
+     * @param string|\Closure $class   A FQCN of a class or a closure that instantiate the class.
+     * @param array           $options The normalized array of options.
+     *
+     * @return object
+     *
+     * @throws ClassInstantiationFailedException
+     */
+    protected static function instantiateClassWithOptions($class, $options)
+    {
+        try {
+            if (is_string($class)) {
+                return new $class($options);
+            }
+
+            if (is_callable($class)) {
+                return $class($options);
+            }
+        } catch (\Exception $e) {
+            throw new ClassInstantiationFailedException('Unexpected exception when instantiating class.', 0, $e);
+        }
+
+        throw new ClassInstantiationFailedException('Could not instantiate class because parameter is neither a callable nor a string');
+    }
+
+    /**
      * We want to do a "safe" version of PHP's "class_exists" because Magento has a bug
      * (or they call it a "feature"). Magento is throwing an exception if you do class_exists()
      * on a class that ends with "Factory" and if that file does not exits.

--- a/src/HttpClientDiscovery.php
+++ b/src/HttpClientDiscovery.php
@@ -15,11 +15,13 @@ final class HttpClientDiscovery extends ClassDiscovery
     /**
      * Finds an HTTP Client.
      *
+     * @param ?array{?connect_timeout: int, ?timeout: int} $options
+     *
      * @return HttpClient
      *
      * @throws Exception\NotFoundException
      */
-    public static function find()
+    public static function find(?array $options = null)
     {
         try {
             $client = static::findOneByType(HttpClient::class);
@@ -27,6 +29,8 @@ final class HttpClientDiscovery extends ClassDiscovery
             throw new NotFoundException('No HTTPlug clients found. Make sure to install a package providing "php-http/client-implementation". Example: "php-http/guzzle6-adapter".', 0, $e);
         }
 
-        return static::instantiateClass($client);
+        return null !== $options
+            ? static::instantiateClassWithOptions($client, $options);
+            : static::instantiateClass($client);
     }
 }

--- a/src/Psr18ClientDiscovery.php
+++ b/src/Psr18ClientDiscovery.php
@@ -15,11 +15,13 @@ final class Psr18ClientDiscovery extends ClassDiscovery
     /**
      * Finds a PSR-18 HTTP Client.
      *
+     * @param ?array{?connect_timeout: int, ?timeout: int} $options
+     *
      * @return ClientInterface
      *
      * @throws Exception\NotFoundException
      */
-    public static function find()
+    public static function find(?array $options = null)
     {
         try {
             $client = static::findOneByType(ClientInterface::class);
@@ -27,6 +29,8 @@ final class Psr18ClientDiscovery extends ClassDiscovery
             throw new \Http\Discovery\Exception\NotFoundException('No PSR-18 clients found. Make sure to install a package providing "psr/http-client-implementation". Example: "php-http/guzzle6-adapter".', 0, $e);
         }
 
-        return static::instantiateClass($client);
+        return null !== $options
+            ? static::instantiateClassWithOptions($client, $options);
+            : static::instantiateClass($client);
     }
 }

--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -100,11 +100,11 @@ final class CommonClassesStrategy implements DiscoveryStrategy
         ],
         Psr18Client::class => [
             [
-                'class' => [self::class, 'symfonyPsr18Instantiate'],
+                'class' => [self::class, 'symfonyPsr18InstantiateWithOptions'],
                 'condition' => [SymfonyPsr18::class, Psr17RequestFactory::class],
             ],
             [
-                'class' => GuzzleHttp::class,
+                'class' => [self::class, 'guzzleInstantiateWithOptions'],
                 'condition' => [self::class, 'isGuzzleImplementingPsr18'],
             ],
             [
@@ -153,9 +153,50 @@ final class CommonClassesStrategy implements DiscoveryStrategy
         return new \Buzz\Client\FileGetContents(MessageFactoryDiscovery::find());
     }
 
+    public static function buzzInstantiateWithOptions(array $options = [])
+    {
+        $convertedOptions = [];
+
+        if (isset($options['timeout']) && is_int($options['timeout']) && $options['timeout'] > 0) {
+            $convertedOptions['timeout'] = $options['timeout'];
+        }
+
+        return new \Buzz\Client\FileGetContents(MessageFactoryDiscovery::find(), $convertedOptions);
+    }
+
+    public static function guzzleInstantiateWithOptions(array $options = [])
+    {
+        $convertedOptions = [];
+
+        if (isset($options['connect_timeout']) && is_int($options['connect_timeout']) && $options['connect_timeout'] > 0) {
+            $convertedOptions['connect_timeout'] = $options['connect_timeout'];
+        }
+
+        if (isset($options['timeout']) && is_int($options['timeout']) && $options['timeout'] > 0) {
+            $convertedOptions['timeout'] = $options['timeout'];
+        }
+
+        return new GuzzleHttp($convertedOptions);
+    }
+
     public static function symfonyPsr18Instantiate()
     {
         return new SymfonyPsr18(null, Psr17FactoryDiscovery::findResponseFactory(), Psr17FactoryDiscovery::findStreamFactory());
+    }
+
+    public static function symfonyPsr18InstantiateWithOptions(array $options = [])
+    {
+        $convertedOptions = [];
+
+        if (isset($options['timeout']) && is_int($options['timeout']) && $options['timeout'] > 0) {
+            $convertedOptions['timeout'] = $options['timeout'];
+        }
+
+        return new SymfonyPsr18(
+            HttpClient::create($convertedOptions),
+            Psr17FactoryDiscovery::findResponseFactory(),
+            Psr17FactoryDiscovery::findStreamFactory(),
+        );
     }
 
     public static function isGuzzleImplementingPsr18()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | TBC
| License         | MIT


#### What's in this PR?

POC for adding support for passing options through to HTTP clients. It is important that these options are standardized, largely supported by every implementation, and that arbitrary implementation specifics are not forwarded, breaking the abstraction. I am initially wanting to support "connect_timeout" and "timeout" only.


#### Why?

These are important because these mostly default to no timeout, leading in blocking for ever (this was recently a problem for me when the github.com API was partially down for multiple hours last month).


#### Example Usage

```
Psr18ClientDiscovery::find(['timeout' => 30]);
```

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] Determine if this feature is wanted
- [ ] Determine what options we want to support
- [ ] Determine if this approach is reasonable, while maintaining BC
- [ ] Determine if we should crash if the resolved client does not support some of the passed options or not
- [ ] Finish implementation
- [ ] Add tests
