### PR TITLE
Remove Zend UriFactory

### DIFF
--- a/src/Strategy/CommonPsr17ClassesStrategy.php
+++ b/src/Strategy/CommonPsr17ClassesStrategy.php
@@ -78,7 +78,6 @@ final class CommonPsr17ClassesStrategy implements DiscoveryStrategy
         UriFactoryInterface::class => [
             'Phalcon\Http\Message\UriFactory',
             'Nyholm\Psr7\Factory\Psr17Factory',
-            'Zend\Diactoros\UriFactory',
             'GuzzleHttp\Psr7\HttpFactory',
             'Http\Factory\Diactoros\UriFactory',
             'Http\Factory\Guzzle\UriFactory',


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

PR is primarily context to explain proposal to remove Zend UriFactory support.


#### Why?

The Zend UriFactory is not PSR-17 compliant in the way that it generates it's URIs.

Example:
```
$uri = new \Zend\Diactoros\Uri('testing');
$this->assertEquals('testing', (string) $uri);
```
This test case would fail as the resulting Uri will actually be `/testing`.

Prepending a `/` is an assumption which has consequences - mentioned on`\Psr\Http\Message\UriInterface`

```
* Normally, the empty path "" and absolute path "/" are considered equal as
* defined in RFC 7230 Section 2.7.3. But this method MUST NOT automatically
* do this normalization because in contexts with a trimmed base path, e.g.
* the front controller, this difference becomes significant. It's the task
* of the user to handle both "" and "/".
```

More info here:
https://github.com/php-fig/http-message/blob/master/src/UriInterface.php#L134


As this UriFactory is prepending a `/` and not allowing the user to handle both `""` and `"/"`, different UriFactories can not be used interchangeably - preventing Liskov Substitution principle here.

Recently this caused us an issue where in many of our services, our new client operated as expected - primarily using versions of Guzzle. However, the Zend UriFactory was used in one of our legacy systems. Since our services have a path as part of their base_uri, this was stripped and our URIs were malformed due to prepending `/` - we addressed this issue by using [league/uri](https://github.com/thephpleague/uri).



#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] The checklist above - primarily raising the PR to first discuss the approach and gain feedback

