### PR TITLE
php 8 is stable now, and use semantic branch name

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,7 +3,7 @@ name: Checks
 on:
   push:
     branches:
-      - master
+      - "*.x"
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - "*.x"
   pull_request:
 
 jobs:
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
 
     steps:
       - name: Checkout code
@@ -25,15 +25,10 @@ jobs:
           tools: composer:v2
           coverage: none
 
-      - name: Install PHP 7 dependencies
-        run: composer update --prefer-dist --no-interaction --no-progress
-        if: "startsWith(matrix.php, '7.')"
-
-      - name: Install PHP 8 dependencies
+      - name: Install dependencies
         run: |
-          composer require "phpdocumentor/reflection-docblock:^5.2@dev" --no-interaction --no-update
-          composer update --prefer-dist --prefer-stable --no-interaction --no-progress --ignore-platform-req=php
-        if: "startsWith(matrix.php, '8.')"
+          composer update --prefer-dist --no-interaction --no-progress
+          vendor/bin/simple-phpunit install
 
       - name: Execute tests
         run: composer test
@@ -61,6 +56,7 @@ jobs:
           wget https://github.com/puli/cli/releases/download/1.0.0-beta9/puli.phar && chmod +x puli.phar
           composer require "sebastian/comparator:^3.0.2" "puli/composer-plugin:1.0.0-beta9" --no-interaction --no-update
           composer update --prefer-dist --prefer-stable --prefer-lowest --no-interaction --no-progress
+          vendor/bin/simple-phpunit install
 
       - name: Execute tests
         run: composer test

--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -2,7 +2,7 @@ name: Installation
 on:
   push:
     branches:
-      - master
+      - "*.x"
   pull_request:
 
 jobs:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -3,7 +3,7 @@ name: Static analysis
 on:
   push:
     branches:
-      - master
+      - "*.x"
   pull_request:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /puli.json
 /vendor/
 .php-cs-fixer.cache
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "php-http/discovery",
     "description": "Finds installed HTTPlug implementations and PSR-7 message factories",
     "license": "MIT",
-    "keywords": ["http", "discovery", "client", "adapter", "message", "factory", "psr7"],
+    "keywords": ["http", "discovery", "client", "adapter", "message", "factory", "psr7", "psr17"],
     "homepage": "http://php-http.org",
     "authors": [
         {
@@ -17,7 +17,8 @@
         "graham-campbell/phpspec-skip-example-extension": "^5.0",
         "php-http/httplug": "^1.0 || ^2.0",
         "php-http/message-factory": "^1.0",
-        "phpspec/phpspec": "^5.1 || ^6.1"
+        "phpspec/phpspec": "^5.1 || ^6.1 || ^7.3",
+        "symfony/phpunit-bridge": "^6.2"
     },
     "suggest": {
         "php-http/message": "Allow to use Guzzle, Diactoros or Slim Framework factories"
@@ -33,13 +34,11 @@
         }
     },
     "scripts": {
-        "test": "vendor/bin/phpspec run",
+        "test": [
+            "vendor/bin/phpspec run",
+            "vendor/bin/simple-phpunit --group NothingInstalled"
+        ],
         "test-ci": "vendor/bin/phpspec run -c phpspec.ci.yml"
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.9-dev"
-        }
     },
     "conflict": {
         "nyholm/psr7": "<1.0"

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -2,13 +2,11 @@
 
 namespace Http\Discovery;
 
-use Throwable;
-
 /**
  * An interface implemented by all discovery related exceptions.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-interface Exception extends Throwable
+interface Exception extends \Throwable
 {
 }

--- a/src/Strategy/PuliBetaStrategy.php
+++ b/src/Strategy/PuliBetaStrategy.php
@@ -11,6 +11,7 @@ use Puli\GeneratedPuliFactory;
  * Find candidates using Puli.
  *
  * @internal
+ *
  * @final
  *
  * @author David de Boer <david@ddeboer.nl>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

Cleanup CI setup.
Semantic branch names instead of `master`