### PR TITLE
Fix handling of replaced packages

### DIFF
--- a/tests/Composer/PluginTest.php
+++ b/tests/Composer/PluginTest.php
@@ -79,5 +79,31 @@ class PluginTest extends TestCase
         ]];
 
         yield 'move-to-require' => [$expected, $repo, $rootRequires, []];
+
+        $package = new Package('symfony/symfony', '1.0.0.0', '1.0');
+        $package->setReplaces([new Link('symfony/symfony', 'symfony/http-client', new Constraint(Constraint::STR_OP_GE, '1'))]);
+
+        $repo = new InstalledArrayRepository([
+            'php-http/discovery' => new Package('php-http/discovery', '1.0.0.0', '1.0'),
+            'symfony/symfony' => $package,
+        ]);
+
+        $rootRequires = [
+            'php-http/discovery' => $link,
+            'php-http/async-client-implementation' => $link,
+            'symfony/symfony' => $link,
+        ];
+
+        $expected = [[
+            'php-http/async-client-implementation' => [
+                'guzzlehttp/promises',
+                'php-http/message-factory',
+            ],
+            'psr/http-factory-implementation' => [
+                'nyholm/psr7',
+            ],
+        ], [], []];
+
+        yield 'replace' => [$expected, $repo, $rootRequires, []];
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/php-http/discovery/issues/213#issuecomment-1426132264
| Documentation   | -
| License         | MIT

Solves https://stackoverflow.com/questions/75414421/is-php-http-discovery-plugin-1-15-1-still-breaking-composer-install-in-contao-4 by taking care of "replace" rules in installed packages.