### PR TITLE
use safe class_exists call to prevent issue with magentos classloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.15.3 - 2023-03-31
+
+- [#224](https://github.com/php-http/discovery/pull/224) - Fix regression with Magento classloader
+
 ## 1.15.2 - 2023-02-11
 
 - [#219](https://github.com/php-http/discovery/pull/219) - Fix handling of replaced packages

--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -18,6 +18,7 @@ use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Repository\RepositorySet;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
+use Http\Discovery\ClassDiscovery;
 
 /**
  * Auto-installs missing implementations.
@@ -187,7 +188,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             return;
         }
 
-        $versionSelector = new VersionSelector(class_exists(RepositorySet::class) ? new RepositorySet() : new Pool());
+        $versionSelector = new VersionSelector(ClassDiscovery::safeClassExists(RepositorySet::class) ? new RepositorySet() : new Pool());
         $updateComposerJson = false;
 
         foreach ($composer->getRepositoryManager()->getLocalRepository()->getPackages() as $package) {
@@ -236,7 +237,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $missingRequires = [[], [], []];
         $versionParser = new VersionParser();
 
-        if (class_exists(\Phalcon\Http\Message\RequestFactory::class, false)) {
+        if (ClassDiscovery::safeClassExists(\Phalcon\Http\Message\RequestFactory::class, false)) {
             $missingRequires[0]['psr/http-factory-implementation'] = [];
             $missingRequires[1]['psr/http-factory-implementation'] = [];
         }
@@ -360,7 +361,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $lock = substr(Factory::getComposerFile(), 0, -4).'lock';
         $composerJson = file_get_contents(Factory::getComposerFile());
         $lockFile = new JsonFile($lock, null, $io);
-        $locker = class_exists(RepositorySet::class)
+        $locker = ClassDiscovery::safeClassExists(RepositorySet::class)
             ? new Locker($io, $lockFile, $composer->getInstallationManager(), $composerJson)
             : new Locker($io, $lockFile, $composer->getRepositoryManager(), $composer->getInstallationManager(), $composerJson);
         $lockData = $locker->getLockData();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #221
| Documentation   | -
| License         | MIT


#### What's in this PR?

We need to catch exeptions during class_exists, because some classloaders (like magento's) throw an exception if the class does not exist.


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix

