### PR TITLE
remove support for obsolete zend diactoros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.16.0 (unreleased)
+
+- [#x]() - Remove support for the abandoned Zend Diactoros which has been replaced with Laminas Diactoros. Marked the zend library as conflict in composer.json to avoid confusion.
+
 ## 1.15.3 - 2023-03-31
 
 - [#224](https://github.com/php-http/discovery/pull/224) - Fix regression with Magento classloader
@@ -31,7 +35,7 @@
 
 ## 1.14.1 - 2021-09-18
 
-- [#199](https://github.com/php-http/discovery/pull/199) - Fixes message factory discovery for `laminas-diactoros ^2.7` 
+- [#199](https://github.com/php-http/discovery/pull/199) - Fixes message factory discovery for `laminas-diactoros ^2.7`
 
 ## 1.14.0 - 2021-06-21
 

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
         "plugin-optional": true
     },
     "conflict": {
-        "nyholm/psr7": "<1.0"
+        "nyholm/psr7": "<1.0",
+        "zendframework/zend-diactoros": "*"
     },
     "prefer-stable": true,
     "minimum-stability": "beta"

--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -75,7 +75,6 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             'slim/psr7' => [],
             'laminas/laminas-diactoros' => [],
             'phalcon/cphalcon:^4' => [],
-            'zendframework/zend-diactoros:>=2' => [],
             'http-interop/http-factory-guzzle' => [],
             'http-interop/http-factory-diactoros' => [],
             'http-interop/http-factory-slim' => [],
@@ -96,7 +95,6 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         'php-http/buzz-adapter' => 'kriswallsmith/buzz:^0.15.1',
         'php-http/artax-adapter' => 'amphp/artax:^3',
         'http-interop/http-factory-guzzle' => 'guzzlehttp/psr7:^1',
-        'http-interop/http-factory-diactoros' => 'zendframework/zend-diactoros:^1',
         'http-interop/http-factory-slim' => 'slim/slim:^3',
     ];
 

--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -12,7 +12,6 @@ use Http\Adapter\Guzzle5\Client as Guzzle5;
 use Http\Adapter\Guzzle6\Client as Guzzle6;
 use Http\Adapter\Guzzle7\Client as Guzzle7;
 use Http\Adapter\React\Client as React;
-use Http\Adapter\Zend\Client as Zend;
 use Http\Client\Curl\Client as Curl;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
@@ -41,7 +40,6 @@ use Psr\Http\Message\RequestFactoryInterface as Psr17RequestFactory;
 use Slim\Http\Request as SlimRequest;
 use Symfony\Component\HttpClient\HttplugClient as SymfonyHttplug;
 use Symfony\Component\HttpClient\Psr18Client as SymfonyPsr18;
-use Zend\Diactoros\Request as ZendDiactorosRequest;
 
 /**
  * @internal
@@ -59,21 +57,18 @@ final class CommonClassesStrategy implements DiscoveryStrategy
         MessageFactory::class => [
             ['class' => NyholmHttplugFactory::class, 'condition' => [NyholmHttplugFactory::class]],
             ['class' => GuzzleMessageFactory::class, 'condition' => [GuzzleRequest::class, GuzzleMessageFactory::class]],
-            ['class' => DiactorosMessageFactory::class, 'condition' => [ZendDiactorosRequest::class, DiactorosMessageFactory::class]],
             ['class' => DiactorosMessageFactory::class, 'condition' => [DiactorosRequest::class, DiactorosMessageFactory::class]],
             ['class' => SlimMessageFactory::class, 'condition' => [SlimRequest::class, SlimMessageFactory::class]],
         ],
         StreamFactory::class => [
             ['class' => NyholmHttplugFactory::class, 'condition' => [NyholmHttplugFactory::class]],
             ['class' => GuzzleStreamFactory::class, 'condition' => [GuzzleRequest::class, GuzzleStreamFactory::class]],
-            ['class' => DiactorosStreamFactory::class, 'condition' => [ZendDiactorosRequest::class, DiactorosStreamFactory::class]],
             ['class' => DiactorosStreamFactory::class, 'condition' => [DiactorosRequest::class, DiactorosStreamFactory::class]],
             ['class' => SlimStreamFactory::class, 'condition' => [SlimRequest::class, SlimStreamFactory::class]],
         ],
         UriFactory::class => [
             ['class' => NyholmHttplugFactory::class, 'condition' => [NyholmHttplugFactory::class]],
             ['class' => GuzzleUriFactory::class, 'condition' => [GuzzleRequest::class, GuzzleUriFactory::class]],
-            ['class' => DiactorosUriFactory::class, 'condition' => [ZendDiactorosRequest::class, DiactorosUriFactory::class]],
             ['class' => DiactorosUriFactory::class, 'condition' => [DiactorosRequest::class, DiactorosUriFactory::class]],
             ['class' => SlimUriFactory::class, 'condition' => [SlimRequest::class, SlimUriFactory::class]],
         ],
@@ -94,7 +89,6 @@ final class CommonClassesStrategy implements DiscoveryStrategy
             ['class' => Buzz::class, 'condition' => Buzz::class],
             ['class' => React::class, 'condition' => React::class],
             ['class' => Cake::class, 'condition' => Cake::class],
-            ['class' => Zend::class, 'condition' => Zend::class],
             ['class' => Artax::class, 'condition' => Artax::class],
             [
                 'class' => [self::class, 'buzzInstantiate'],

--- a/src/Strategy/CommonPsr17ClassesStrategy.php
+++ b/src/Strategy/CommonPsr17ClassesStrategy.php
@@ -25,7 +25,6 @@ final class CommonPsr17ClassesStrategy implements DiscoveryStrategy
         RequestFactoryInterface::class => [
             'Phalcon\Http\Message\RequestFactory',
             'Nyholm\Psr7\Factory\Psr17Factory',
-            'Zend\Diactoros\RequestFactory',
             'GuzzleHttp\Psr7\HttpFactory',
             'Http\Factory\Diactoros\RequestFactory',
             'Http\Factory\Guzzle\RequestFactory',
@@ -36,7 +35,6 @@ final class CommonPsr17ClassesStrategy implements DiscoveryStrategy
         ResponseFactoryInterface::class => [
             'Phalcon\Http\Message\ResponseFactory',
             'Nyholm\Psr7\Factory\Psr17Factory',
-            'Zend\Diactoros\ResponseFactory',
             'GuzzleHttp\Psr7\HttpFactory',
             'Http\Factory\Diactoros\ResponseFactory',
             'Http\Factory\Guzzle\ResponseFactory',
@@ -47,7 +45,6 @@ final class CommonPsr17ClassesStrategy implements DiscoveryStrategy
         ServerRequestFactoryInterface::class => [
             'Phalcon\Http\Message\ServerRequestFactory',
             'Nyholm\Psr7\Factory\Psr17Factory',
-            'Zend\Diactoros\ServerRequestFactory',
             'GuzzleHttp\Psr7\HttpFactory',
             'Http\Factory\Diactoros\ServerRequestFactory',
             'Http\Factory\Guzzle\ServerRequestFactory',
@@ -58,7 +55,6 @@ final class CommonPsr17ClassesStrategy implements DiscoveryStrategy
         StreamFactoryInterface::class => [
             'Phalcon\Http\Message\StreamFactory',
             'Nyholm\Psr7\Factory\Psr17Factory',
-            'Zend\Diactoros\StreamFactory',
             'GuzzleHttp\Psr7\HttpFactory',
             'Http\Factory\Diactoros\StreamFactory',
             'Http\Factory\Guzzle\StreamFactory',
@@ -69,7 +65,6 @@ final class CommonPsr17ClassesStrategy implements DiscoveryStrategy
         UploadedFileFactoryInterface::class => [
             'Phalcon\Http\Message\UploadedFileFactory',
             'Nyholm\Psr7\Factory\Psr17Factory',
-            'Zend\Diactoros\UploadedFileFactory',
             'GuzzleHttp\Psr7\HttpFactory',
             'Http\Factory\Diactoros\UploadedFileFactory',
             'Http\Factory\Guzzle\UploadedFileFactory',
@@ -80,7 +75,6 @@ final class CommonPsr17ClassesStrategy implements DiscoveryStrategy
         UriFactoryInterface::class => [
             'Phalcon\Http\Message\UriFactory',
             'Nyholm\Psr7\Factory\Psr17Factory',
-            'Zend\Diactoros\UriFactory',
             'GuzzleHttp\Psr7\HttpFactory',
             'Http\Factory\Diactoros\UriFactory',
             'Http\Factory\Guzzle\UriFactory',


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #205
| Documentation   | -
| License         | MIT


#### What's in this PR?

Drop Zend Diactoros support and mark newer versions of discovery as conflicting with it.


#### Why?

Zend diactoros got renamed to laminas diactorors and the old zend version is no longer maintained. The priorities if both are installed is to pick zend over laminas. Rather than change priorities, we just drop zend support.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix)
