### PR TITLE
Allow pinning the preferred implementations in composer.json

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Roave BC Check
         uses: "docker://nyholm/roave-bc-check-ga"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -26,11 +26,20 @@ jobs:
           php-version: 7.1
           tools: composer:${{ matrix.composer }}
 
-      - name: Check Plugin
+      - name: Check Auto-install
         run: |
-          mkdir /tmp/plugin
+          mkdir /tmp/plugin-auto-install
           # replace the relative path for the repository url with an absolute path for composer v1 compatibility
-          jq '.repositories[0].url="'$(pwd)'"' tests/plugin/composer.json > /tmp/plugin/composer.json
-          cd /tmp/plugin
+          jq '.repositories[0].url="'$(pwd)'"' tests/plugin/auto-install/composer.json > /tmp/plugin-auto-install/composer.json
+          cd /tmp/plugin-auto-install
           composer update
           composer show http-interop/http-factory-guzzle -q
+
+      - name: Check Pinning
+        run: |
+          cp -a tests/plugin/pinning /tmp/plugin-pinning
+          # replace the relative path for the repository url with an absolute path for composer v1 compatibility
+          jq '.repositories[0].url="'$(pwd)'"' tests/plugin/pinning/composer.json > /tmp/plugin-pinning/composer.json
+          cd /tmp/plugin-pinning
+          composer update
+          [ 'Slim\Psr7\Factory\RequestFactory' == $(php test.php) ]

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: PHP-CS-Fixer
         uses: docker://oskarstark/php-cs-fixer-ga

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.17.0 - 2023-XX-XX
 
 - [#230](https://github.com/php-http/discovery/pull/230) - Add Psr18Client to make it straightforward to use PSR-18
+- [#232](https://github.com/php-http/discovery/pull/232) - Allow pinning the preferred implementations in composer.json
 
 ## 1.16.0 - 2023-04-26
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,15 @@ composer require php-http/discovery
 ```
 
 
-## Usage
+## Usage as a library author
 
 Please see the [official documentation](http://php-http.readthedocs.org/en/latest/discovery.html).
 
 If your library/SDK needs a PSR-18 client, here is a quick example.
 
-First, you need to install a PSR-18 client and a PSR-17 factory implementations. This should
-be done only for dev dependencies as you don't want to force a specific one on your users:
+First, you need to install a PSR-18 client and a PSR-17 factory implementations.
+This should be done only for dev dependencies as you don't want to force a
+specific implementation on your users:
 
 ```bash
 composer require --dev symfony/http-client
@@ -40,8 +41,8 @@ because you just installed the dev dependencies you need for testing:
 composer config allow-plugins.php-http/discovery false
 ```
 
-Finally, you need to require `php-http/discovery` and the generic implementations that
-your library is going to need:
+Finally, you need to require `php-http/discovery` and the generic implementations
+that your library is going to need:
 
 ```bash
 composer require php-http/discovery:^1.17
@@ -60,7 +61,44 @@ $request = $client->createRequest('GET', 'https://example.com');
 $response = $client->sendRequest($request);
 ```
 
-Internally, this code will use whatever PSR-7, PSR-17 and PSR-18 implementations that your users have installed.
+Internally, this code will use whatever PSR-7, PSR-17 and PSR-18 implementations
+that your users have installed.
+
+
+## Usage as a library user
+
+If you use a library/SDK that requires `php-http/discovery`, you can configure
+the auto-discovery mechanism to use a specific implementation when many are
+available in your project.
+
+For example, if you have both `nyholm/psr7` and `guzzlehttp/guzzle` in your
+project, you can tell `php-http/discovery` to use `guzzlehttp/guzzle` instead of
+`nyholm/psr7` by running the following command:
+
+```bash
+composer config extra.discovery.psr/http-factory-implementation GuzzleHttp\\Psr7\\HttpFactory
+```
+
+This will update your `composer.json` file to add the following configuration:
+
+```json
+{
+    "extra": {
+        "discovery": {
+            "psr/http-factory-implementation": "GuzzleHttp\\Psr7\\HttpFactory"
+        }
+    }
+}
+```
+
+Don't forget to run `composer install` to apply the changes, and ensure that
+the composer plugin is enabled:
+
+```bash
+composer config allow-plugins.php-http/discovery true
+composer install
+```
+
 
 ## Testing
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,10 @@
     "autoload": {
         "psr-4": {
             "Http\\Discovery\\": "src/"
-        }
+        },
+        "exclude-from-classmap": [
+            "src/Composer/Plugin.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/tests/Composer/PluginTest.php
+++ b/tests/Composer/PluginTest.php
@@ -81,7 +81,9 @@ class PluginTest extends TestCase
         yield 'move-to-require' => [$expected, $repo, $rootRequires, []];
 
         $package = new Package('symfony/symfony', '1.0.0.0', '1.0');
-        $package->setReplaces([new Link('symfony/symfony', 'symfony/http-client', new Constraint(Constraint::STR_OP_GE, '1'))]);
+        $package->setReplaces([
+            'symfony/http-client' => new Link('symfony/symfony', 'symfony/http-client', new Constraint(Constraint::STR_OP_GE, '1'))
+        ]);
 
         $repo = new InstalledArrayRepository([
             'php-http/discovery' => new Package('php-http/discovery', '1.0.0.0', '1.0'),

--- a/tests/plugin/.gitignore
+++ b/tests/plugin/.gitignore
@@ -1,2 +1,2 @@
-/vendor
-/composer.lock
+vendor
+composer.lock

--- a/tests/plugin/auto-install/composer.json
+++ b/tests/plugin/auto-install/composer.json
@@ -2,7 +2,7 @@
     "repositories": [
         {
             "type": "path",
-            "url": "../..",
+            "url": "../../..",
             "options": {
                 "versions": {
                     "php-http/discovery": "99.99.x-dev"

--- a/tests/plugin/pinning/composer.json
+++ b/tests/plugin/pinning/composer.json
@@ -1,0 +1,28 @@
+{
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../..",
+            "options": {
+                "versions": {
+                    "php-http/discovery": "99.99.x-dev"
+                }
+            }
+        }
+    ],
+    "require": {
+        "nyholm/psr7": "*",
+        "php-http/discovery": "99.99.x-dev",
+        "slim/psr7": "*"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
+    },
+    "extra": {
+        "discovery": {
+            "Psr\\Http\\Message\\RequestFactoryInterface": "Slim\\Psr7\\Factory\\RequestFactory"
+        }
+    }
+}

--- a/tests/plugin/pinning/test.php
+++ b/tests/plugin/pinning/test.php
@@ -1,0 +1,7 @@
+<?php
+
+use Http\Discovery\Psr17FactoryDiscovery;
+
+require __DIR__.'/vendor/autoload.php';
+
+echo get_class(Psr17FactoryDiscovery::findRequestFactory())."\n";


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #223
| Documentation   | TBD
| License         | MIT

Add this to your composer.json to pin guzzle as PSR-17 implementation even if nyholm/psr7 is installed:
```json
    "extra": {
        "discovery": {
            "psr/http-factory-implementation": "GuzzleHttp\\Psr7\\HttpFactory"
        }
    }
```

This also works for single interfaces:
```json
    "extra": {
        "discovery": {
            "Psr\\Http\\Message\\RequestFactoryInterface": "Slim\\Psr7\\Factory\\RequestFactory"
        }
    }
```