### PR TITLE
Fix Psr17Factory::createServerRequestFromGlobals() when uploaded files have been moved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#230](https://github.com/php-http/discovery/pull/230) - Add Psr18Client to make it straightforward to use PSR-18
 - [#232](https://github.com/php-http/discovery/pull/232) - Allow pinning the preferred implementations in composer.json
+- [#233](https://github.com/php-http/discovery/pull/233) - Fix Psr17Factory::createServerRequestFromGlobals() when uploaded files have been moved
 
 ## 1.16.0 - 2023-04-26
 

--- a/src/Psr17Factory.php
+++ b/src/Psr17Factory.php
@@ -283,7 +283,7 @@ class Psr17Factory implements RequestFactoryInterface, ResponseFactoryInterface,
     private function createUploadedFileFromSpec(array $value)
     {
         if (!is_array($tmpName = $value['tmp_name'])) {
-            $file = $this->createStreamFromFile($tmpName, 'r');
+            $file = is_file($tmpName) ? $this->createStreamFromFile($tmpName, 'r') : $this->createStream();
 
             return $this->createUploadedFile($file, $value['size'], $value['error'], $value['name'], $value['type']);
         }

--- a/tests/Psr17FactoryTest.php
+++ b/tests/Psr17FactoryTest.php
@@ -282,14 +282,14 @@ class Psr17FactoryTest extends TestCase
             'file' => [
                 'name' => 'MyFile.txt',
                 'type' => 'text/plain',
-                'tmp_name' => 'php://memory',
+                'tmp_name' => __FILE__,
                 'error' => UPLOAD_ERR_OK,
                 'size' => 123,
             ],
             'files' => [
                 'name' => ['file_0' => ['NestedFile.txt']],
                 'type' => ['file_0' => ['text/plain']],
-                'tmp_name' => ['file_0' => ['php://memory']],
+                'tmp_name' => ['file_0' => ['/not-exists']],
                 'error' => ['file_0' => [UPLOAD_ERR_OK]],
                 'size' => ['file_0' => [123]],
             ],
@@ -339,5 +339,8 @@ class Psr17FactoryTest extends TestCase
         ];
 
         self::assertEquals($expectedFiles, $server->getUploadedFiles());
+
+        self::assertSame('plainfile', $server->getUploadedFiles()['file']->getStream()->getMetadata()['wrapper_type']);
+        self::assertSame('PHP', $server->getUploadedFiles()['files']['file_0'][0]->getStream()->getMetadata()['wrapper_type']);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #231
| Documentation   | -
| License         | MIT

