### PR TITLE
Skip requiring php-http/message-factory when installing symfony/http-client 6.3+

### DIFF
--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -31,7 +31,7 @@ jobs:
             method: "Http\\Discovery\\HttpClientDiscovery::find();"
           # We should fail if we dont have php-http/message-factory or PSR-17
           - expect: cant-find
-            requirements: "symfony/http-client:^5 php-http/httplug php-http/message-factory guzzlehttp/psr7:^1"
+            requirements: "symfony/http-client:^5 php-http/httplug guzzlehttp/psr7:^1"
             method: "Http\\Discovery\\HttpClientDiscovery::find();"
           - expect: cant-find
             requirements: "symfony/http-client:^5 php-http/httplug guzzlehttp/psr7:^1 http-interop/http-factory-guzzle"
@@ -58,11 +58,11 @@ jobs:
             method: "Http\\Discovery\\Psr18ClientDiscovery::find();"
           # Test that we find PSR-18 Symfony 4
           - expect: will-find
-            requirements: "symfony/http-client:^4 php-http/httplug nyholm/psr7:^1.3"
+            requirements: "symfony/http-client:^4 php-http/httplug php-http/message-factory nyholm/psr7:^1.3"
             method: "Http\\Discovery\\Psr18ClientDiscovery::find();"
           # Test that we find PSR-18 Symfony 5
           - expect: will-find
-            requirements: "symfony/http-client:^5 php-http/httplug nyholm/psr7:^1.3"
+            requirements: "symfony/http-client:^5 php-http/httplug php-http/message-factory nyholm/psr7:^1.3"
             method: "Http\\Discovery\\Psr18ClientDiscovery::find();"
           # Test that we find PSR-17 http-interop
           - expect: will-find

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.18.0 - 2023-XX-XX
 
 - [#235](https://github.com/php-http/discovery/pull/235) - Deprecate HttpClientDiscovery, use Psr18ClientDiscovery instead
+- [#238](https://github.com/php-http/discovery/pull/238) - Skip requiring php-http/message-factory when installing symfony/http-client 6.3+
 
 ## 1.17.0 - 2023-04-26
 

--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -45,6 +45,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     private const PROVIDE_RULES = [
         'php-http/async-client-implementation' => [
+            'symfony/http-client:>=6.3' => ['guzzlehttp/promises', 'psr/http-factory-implementation'],
             'symfony/http-client' => ['guzzlehttp/promises', 'php-http/message-factory', 'psr/http-factory-implementation'],
             'php-http/guzzle7-adapter' => [],
             'php-http/guzzle6-adapter' => [],
@@ -52,6 +53,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             'php-http/react-adapter' => [],
         ],
         'php-http/client-implementation' => [
+            'symfony/http-client:>=6.3' => ['psr/http-factory-implementation'],
             'symfony/http-client' => ['php-http/message-factory', 'psr/http-factory-implementation'],
             'php-http/guzzle7-adapter' => [],
             'php-http/guzzle6-adapter' => [],
@@ -332,21 +334,11 @@ class Plugin implements PluginInterface, EventSubscriberInterface
                 }
 
                 $dep = key($candidates);
+                [$dep] = explode(':', $dep, 2);
                 $missingRequires[$dev][$abstraction] = [$dep];
 
                 if ($isProject && !$dev && isset($devPackages[$dep])) {
                     $missingRequires[2][$abstraction][] = $dep;
-                }
-
-                foreach (current($candidates) as $dep) {
-                    if (isset(self::PROVIDE_RULES[$dep])) {
-                        $abstractions[] = $dep;
-                    } elseif (!isset($allPackages[$dep])) {
-                        $missingRequires[$dev][$abstraction][] = $dep;
-                    } elseif ($isProject && !$dev && isset($devPackages[$dep])) {
-                        $missingRequires[0][$abstraction][] = $dep;
-                        $missingRequires[2][$abstraction][] = $dep;
-                    }
                 }
             }
         }

--- a/tests/Composer/PluginTest.php
+++ b/tests/Composer/PluginTest.php
@@ -42,8 +42,6 @@ class PluginTest extends TestCase
             'psr/http-message-implementation' => [],
             'php-http/async-client-implementation' => [
                 'symfony/http-client',
-                'guzzlehttp/promises',
-                'php-http/message-factory',
             ],
             'psr/http-factory-implementation' => [
                 'nyholm/psr7',
@@ -60,15 +58,10 @@ class PluginTest extends TestCase
 
         $rootRequires = [
             'php-http/discovery' => $link,
-            'php-http/async-client-implementation' => $link,
+            'psr/http-factory-implementation' => $link,
         ];
 
         $expected = [[
-            'php-http/async-client-implementation' => [
-                'symfony/http-client',
-                'guzzlehttp/promises',
-                'php-http/message-factory',
-            ],
             'psr/http-factory-implementation' => [
                 'nyholm/psr7',
             ],


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT

After https://github.com/symfony/symfony/pull/50225, Symfony's `HttplugClient` won't require `php-http/message-factory` anymore.
