### PR TITLE
Skip auto-installing when the root package's extra.discovery is enough

### DIFF
--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -42,4 +42,4 @@ jobs:
           jq '.repositories[0].url="'$(pwd)'"' tests/plugin/pinning/composer.json > /tmp/plugin-pinning/composer.json
           cd /tmp/plugin-pinning
           composer update
-          [ 'Slim\Psr7\Factory\RequestFactory' == $(php test.php) ]
+          [ 'Slim\Psr7\Factory\RequestFactory-MyClient' == $(php test.php) ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change Log
 
-## 1.18.0 - 2023-XX-XX
+## 1.18.0 - 2023-05-03
 
 - [#235](https://github.com/php-http/discovery/pull/235) - Deprecate HttpClientDiscovery, use Psr18ClientDiscovery instead
 - [#238](https://github.com/php-http/discovery/pull/238) - Skip requiring php-http/message-factory when installing symfony/http-client 6.3+
+- [#239](https://github.com/php-http/discovery/pull/239) - Skip auto-installing when the root package's extra.discovery is enough
 
 ## 1.17.0 - 2023-04-26
 

--- a/tests/Composer/PluginTest.php
+++ b/tests/Composer/PluginTest.php
@@ -17,11 +17,11 @@ class PluginTest extends TestCase
     /**
      * @dataProvider provideMissingRequires
      */
-    public function testMissingRequires(array $expected, InstalledArrayRepository $repo, array $rootRequires, array $rootDevRequires)
+    public function testMissingRequires(array $expected, InstalledArrayRepository $repo, array $rootRequires, array $rootDevRequires, $pinnedAbstractions = [])
     {
         $plugin = new Plugin();
 
-        $this->assertSame($expected, $plugin->getMissingRequires($repo, [$rootRequires, $rootDevRequires], true));
+        $this->assertSame($expected, $plugin->getMissingRequires($repo, [$rootRequires, $rootDevRequires], true, $pinnedAbstractions));
     }
 
     public static function provideMissingRequires()
@@ -49,6 +49,10 @@ class PluginTest extends TestCase
         ], [], []];
 
         yield 'async-httplug' => [$expected, $repo, $rootRequires, []];
+
+        unset($expected[0]['php-http/async-client-implementation']);
+
+        yield 'pinned' => [$expected, $repo, $rootRequires, [], ['php-http/async-client-implementation' => true]];
 
         $repo = new InstalledArrayRepository([
             'php-http/discovery' => new Package('php-http/discovery', '1.0.0.0', '1.0'),

--- a/tests/plugin/pinning/composer.json
+++ b/tests/plugin/pinning/composer.json
@@ -13,6 +13,8 @@
     "require": {
         "nyholm/psr7": "*",
         "php-http/discovery": "99.99.x-dev",
+        "psr/http-client": "*",
+        "psr/http-client-implementation": "*",
         "slim/psr7": "*"
     },
     "config": {
@@ -22,6 +24,7 @@
     },
     "extra": {
         "discovery": {
+            "Psr\\Http\\Client\\ClientInterface": "MyClient",
             "Psr\\Http\\Message\\RequestFactoryInterface": "Slim\\Psr7\\Factory\\RequestFactory"
         }
     }

--- a/tests/plugin/pinning/test.php
+++ b/tests/plugin/pinning/test.php
@@ -1,7 +1,21 @@
 <?php
 
 use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 require __DIR__.'/vendor/autoload.php';
 
-echo get_class(Psr17FactoryDiscovery::findRequestFactory())."\n";
+class MyClient implements ClientInterface
+{
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        return Psr17FactoryDiscovery::findResponseFactory()->createResponse();
+    }
+}
+
+echo get_class(Psr17FactoryDiscovery::findRequestFactory());
+echo '-', get_class(Psr18ClientDiscovery::find());
+echo "\n";


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #237
| Documentation   | -
| License         | MIT

