### PR TITLE
better exception message when no php-http message factories are found

### DIFF
--- a/src/MessageFactoryDiscovery.php
+++ b/src/MessageFactoryDiscovery.php
@@ -26,7 +26,7 @@ final class MessageFactoryDiscovery extends ClassDiscovery
         try {
             $messageFactory = static::findOneByType(MessageFactory::class);
         } catch (DiscoveryFailedException $e) {
-            throw new NotFoundException('No message factories found. To use Guzzle, Diactoros or Slim Framework factories install php-http/message and the chosen message implementation.', 0, $e);
+            throw new NotFoundException('No php-http message factories found. Note that the php-http message factories are deprecated in favor of the PSR-17 message factories. To use the legacy Guzzle, Diactoros or Slim Framework factories of php-http, install php-http/message and php-http/message-factory and the chosen message implementation.', 0, $e);
         }
 
         return static::instantiateClass($messageFactory);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/php-http/message/pull/152#issuecomment-1550924383
| Documentation   | -
| License         | MIT

