### PR TITLE
Update README example to work in ZSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Finally, you need to require `php-http/discovery` and the generic implementation
 that your library is going to need:
 
 ```bash
-composer require php-http/discovery:^1.17
-composer require psr/http-client-implementation:*
-composer require psr/http-factory-implementation:*
+composer require 'php-http/discovery:^1.17'
+composer require 'psr/http-client-implementation:*'
+composer require 'psr/http-factory-implementation:*'
 ```
 
 Now, you're ready to make an HTTP request:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes?
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| Documentation   | yes
| License         | MIT


#### What's in this PR?

Just quotes the example in the README

#### Why?

zsh and likely some other shells try to glob the * and cause the lines to fail.

<img width="590" alt="image" src="https://github.com/php-http/discovery/assets/133747/912c72f5-5b74-4fd9-b122-c80f8cefda4f">

zsh being the default shell on macOS now, seems like it should get fixed.

I quoted the first option for visual symmetry but it doesn't really require it.

#### Example Usage


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

