### PR TITLE
Fix deprecated tag for http client discovery

### DIFF
--- a/src/HttpClientDiscovery.php
+++ b/src/HttpClientDiscovery.php
@@ -10,7 +10,7 @@ use Http\Discovery\Exception\DiscoveryFailedException;
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
  *
- * @deprecated This will be removed in 2.0. Consider using Psr18FactoryDiscovery.
+ * @deprecated This will be removed in 2.0. Consider using Psr18ClientDiscovery.
  */
 final class HttpClientDiscovery extends ClassDiscovery
 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Deprecations?   | no|yes
| Related tickets | N/A
| Documentation   | N/A
| License         | MIT


#### What's in this PR?

Corrected deprecated tag in `HttpClientDiscovery` which was suggesting to use `Psr18FactoryDiscovery` and should have been `Psr18ClientDiscovery`


#### Why?

Which problem does the PR fix? (remove this section if you linked an issue above)


#### Example Usage

N/A

#### Checklist

N/A


#### To Do

N/A
