### PR TITLE
add missing requirements of symfony/http-client to composer plugin

### DIFF
--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -45,16 +45,16 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     private const PROVIDE_RULES = [
         'php-http/async-client-implementation' => [
-            'symfony/http-client:>=6.3' => ['guzzlehttp/promises', 'psr/http-factory-implementation'],
-            'symfony/http-client' => ['guzzlehttp/promises', 'php-http/message-factory', 'psr/http-factory-implementation'],
+            'symfony/http-client:>=6.3' => ['guzzlehttp/promises', 'psr/http-factory-implementation', 'php-http/httplug'],
+            'symfony/http-client' => ['guzzlehttp/promises', 'php-http/message-factory', 'psr/http-factory-implementation', 'php-http/httplug'],
             'php-http/guzzle7-adapter' => [],
             'php-http/guzzle6-adapter' => [],
             'php-http/curl-client' => [],
             'php-http/react-adapter' => [],
         ],
         'php-http/client-implementation' => [
-            'symfony/http-client:>=6.3' => ['psr/http-factory-implementation'],
-            'symfony/http-client' => ['php-http/message-factory', 'psr/http-factory-implementation'],
+            'symfony/http-client:>=6.3' => ['psr/http-factory-implementation', 'php-http/httplug'],
+            'symfony/http-client' => ['php-http/message-factory', 'psr/http-factory-implementation', 'php-http/httplug'],
             'php-http/guzzle7-adapter' => [],
             'php-http/guzzle6-adapter' => [],
             'php-http/cakephp-adapter' => [],
@@ -65,7 +65,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             'kriswallsmith/buzz:^1' => [],
         ],
         'psr/http-client-implementation' => [
-            'symfony/http-client' => ['psr/http-factory-implementation'],
+            'symfony/http-client' => ['psr/http-factory-implementation', 'psr/http-client'],
             'guzzlehttp/guzzle' => [],
             'kriswallsmith/buzz:^1' => [],
         ],

--- a/tests/Composer/PluginTest.php
+++ b/tests/Composer/PluginTest.php
@@ -97,6 +97,7 @@ class PluginTest extends TestCase
             'php-http/async-client-implementation' => [
                 'guzzlehttp/promises',
                 'php-http/message-factory',
+                'php-http/httplug',
             ],
             'psr/http-factory-implementation' => [
                 'nyholm/psr7',


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #248
| Documentation   | -
| License         | MIT


#### What's in this PR?

As discovered in #248, the composer plugin does not install a functional set of dependencies to actually discover the psr18 client when installing symfony/http-client.


#### Reproduce

To reproduce the problem, create an empty folder, create `composer.json` with the following content and run `composer update`:

```
{
  "config": {
    "allow-plugins": {
      "php-http/discovery": true
    }
  },
  "require": {
    "psr/http-client-implementation": "*",
    "php-http/discovery": "^1.18"
  }
}
```

`ls vendor/psr` shows that psr/http-client is not installed.

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
