### PR TITLE
fix: buzz client instantiation using deprecated Message Factory Discovery

### DIFF
--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -18,7 +18,6 @@ use Http\Client\HttpClient;
 use Http\Client\Socket\Client as Socket;
 use Http\Discovery\ClassDiscovery;
 use Http\Discovery\Exception\NotFoundException;
-use Http\Discovery\MessageFactoryDiscovery;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Message\MessageFactory;
 use Http\Message\MessageFactory\DiactorosMessageFactory;
@@ -146,7 +145,7 @@ final class CommonClassesStrategy implements DiscoveryStrategy
 
     public static function buzzInstantiate()
     {
-        return new \Buzz\Client\FileGetContents(MessageFactoryDiscovery::find());
+        return new \Buzz\Client\FileGetContents(Psr17FactoryDiscovery::findResponseFactory());
     }
 
     public static function symfonyPsr18Instantiate()


### PR DESCRIPTION
Fixes the instantiation of Buzz client to use the new `Psr17FactoryDiscovery` instead of the deprecated `MessageFactoryDiscovery`.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no|
| Deprecations?   | no
| Related tickets | none
| Documentation   | none
| License         | MIT


#### What's in this PR?

Change Buzz instantiator from the deprecated `MessageFactoryDisvovery` to the new `Psr17FactoryDiscovery`. 

#### Why?

The Buzz Instantiator was using the deprectaed `MessageFactoryDiscovery` and this was causing an exception when attempting to instantiate Buzz using `nyholm/psr7`. Changed to the more modern `Psr17FactoryDiscovery` that does find `nyholm/psr7` for Buzz.

#### Example Usage
Noop

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)