### PR TITLE
Check if SymfonyHttplug actually implements HttpClient

### DIFF
--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -160,7 +160,7 @@ final class CommonClassesStrategy implements DiscoveryStrategy
 
     public static function isSymfonyImplementingHttpClient()
     {
-        return is_a(SymfonyHttplug::class, HttpClient::class, true);
+        return is_subclass_of(SymfonyHttplug::class, HttpClient::class);
     }
 
     /**

--- a/src/Strategy/CommonClassesStrategy.php
+++ b/src/Strategy/CommonClassesStrategy.php
@@ -78,7 +78,7 @@ final class CommonClassesStrategy implements DiscoveryStrategy
             ['class' => React::class, 'condition' => React::class],
         ],
         HttpClient::class => [
-            ['class' => SymfonyHttplug::class, 'condition' => [SymfonyHttplug::class, [self::class, 'isPsr17FactoryInstalled']]],
+            ['class' => SymfonyHttplug::class, 'condition' => [SymfonyHttplug::class, [self::class, 'isPsr17FactoryInstalled'], [self::class, 'isSymfonyImplementingHttpClient']]],
             ['class' => Guzzle7::class, 'condition' => Guzzle7::class],
             ['class' => Guzzle6::class, 'condition' => Guzzle6::class],
             ['class' => Guzzle5::class, 'condition' => Guzzle5::class],
@@ -156,6 +156,11 @@ final class CommonClassesStrategy implements DiscoveryStrategy
     public static function isGuzzleImplementingPsr18()
     {
         return defined('GuzzleHttp\ClientInterface::MAJOR_VERSION');
+    }
+
+    public static function isSymfonyImplementingHttpClient()
+    {
+        return is_a(SymfonyHttplug::class, HttpClient::class, true);
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #252
| License         | MIT


#### What's in this PR?

When looking for HttpClient, check if SymfonyHttplug actually implements HttpClient.


#### Why?

In Symfony 7, SymfonyHttplug no longer implements HttpClient


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
