### PR TITLE
Avoid pulling sebastian/comparator v5 not compatible with phpunit v10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
     },
     "conflict": {
         "nyholm/psr7": "<1.0",
+        "sebastian/comparator": ">=5.0",
         "zendframework/zend-diactoros": "*"
     },
     "prefer-stable": true,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

Avoid pulling sebastian/comparator version 5 which is not compatible with phpunit version 10

#### Why?

Running the project locally fails to pass the tests as it's pulling phpunit version 10 which is not compatible with sebastian/comparator version 5 for the SebastianBergmann\Comparator\Comparator::assertEquals assertion.

How to reproduce it

```
composer inst
composer test

PHP Fatal error:  Declaration of SebastianBergmann\Comparator\ArrayComparator::assertEquals(mixed $expected, mixed $actual, float $delta = 0, bool $canonicalize = false, bool $ignoreCase = false, array &$processed = []): void must be compatible with SebastianBergmann\Comparator\Comparator::assertEquals($expected, $actual, $delta = 0, $canonicalize = false, $ignoreCase = false) in /Users/cindyleschaud/Projects/discovery/vendor/sebastian/comparator/src/ArrayComparator.php on line 36
```

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
