### PR TITLE
explicitly mark nullable parameters as nullable

### DIFF
--- a/src/Psr17Factory.php
+++ b/src/Psr17Factory.php
@@ -49,12 +49,12 @@ class Psr17Factory implements RequestFactoryInterface, ResponseFactoryInterface,
     private $uriFactory;
 
     public function __construct(
-        RequestFactoryInterface $requestFactory = null,
-        ResponseFactoryInterface $responseFactory = null,
-        ServerRequestFactoryInterface $serverRequestFactory = null,
-        StreamFactoryInterface $streamFactory = null,
-        UploadedFileFactoryInterface $uploadedFileFactory = null,
-        UriFactoryInterface $uriFactory = null
+        ?RequestFactoryInterface $requestFactory = null,
+        ?ResponseFactoryInterface $responseFactory = null,
+        ?ServerRequestFactoryInterface $serverRequestFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
+        ?UploadedFileFactoryInterface $uploadedFileFactory = null,
+        ?UriFactoryInterface $uriFactory = null
     ) {
         $this->requestFactory = $requestFactory;
         $this->responseFactory = $responseFactory;
@@ -98,7 +98,7 @@ class Psr17Factory implements RequestFactoryInterface, ResponseFactoryInterface,
         return $factory->createServerRequest(...\func_get_args());
     }
 
-    public function createServerRequestFromGlobals(array $server = null, array $get = null, array $post = null, array $cookie = null, array $files = null, StreamInterface $body = null): ServerRequestInterface
+    public function createServerRequestFromGlobals(?array $server = null, ?array $get = null, ?array $post = null, ?array $cookie = null, ?array $files = null, ?StreamInterface $body = null): ServerRequestInterface
     {
         $server = $server ?? $_SERVER;
         $request = $this->createServerRequest($server['REQUEST_METHOD'] ?? 'GET', $this->createUriFromGlobals($server), $server);
@@ -134,7 +134,7 @@ class Psr17Factory implements RequestFactoryInterface, ResponseFactoryInterface,
         return $factory->createStreamFromResource($resource);
     }
 
-    public function createUploadedFile(StreamInterface $stream, int $size = null, int $error = \UPLOAD_ERR_OK, string $clientFilename = null, string $clientMediaType = null): UploadedFileInterface
+    public function createUploadedFile(StreamInterface $stream, ?int $size = null, int $error = \UPLOAD_ERR_OK, ?string $clientFilename = null, ?string $clientMediaType = null): UploadedFileInterface
     {
         $factory = $this->uploadedFileFactory ?? $this->setFactory(Psr17FactoryDiscovery::findUploadedFileFactory());
 
@@ -148,7 +148,7 @@ class Psr17Factory implements RequestFactoryInterface, ResponseFactoryInterface,
         return $factory->createUri(...\func_get_args());
     }
 
-    public function createUriFromGlobals(array $server = null): UriInterface
+    public function createUriFromGlobals(?array $server = null): UriInterface
     {
         return $this->buildUriFromGlobals($this->createUri(''), $server ?? $_SERVER);
     }

--- a/src/Psr18Client.php
+++ b/src/Psr18Client.php
@@ -25,13 +25,13 @@ class Psr18Client extends Psr17Factory implements ClientInterface
     private $client;
 
     public function __construct(
-        ClientInterface $client = null,
-        RequestFactoryInterface $requestFactory = null,
-        ResponseFactoryInterface $responseFactory = null,
-        ServerRequestFactoryInterface $serverRequestFactory = null,
-        StreamFactoryInterface $streamFactory = null,
-        UploadedFileFactoryInterface $uploadedFileFactory = null,
-        UriFactoryInterface $uriFactory = null
+        ?ClientInterface $client = null,
+        ?RequestFactoryInterface $requestFactory = null,
+        ?ResponseFactoryInterface $responseFactory = null,
+        ?ServerRequestFactoryInterface $serverRequestFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
+        ?UploadedFileFactoryInterface $uploadedFileFactory = null,
+        ?UriFactoryInterface $uriFactory = null
     ) {
         parent::__construct($requestFactory, $responseFactory, $serverRequestFactory, $streamFactory, $uploadedFileFactory, $uriFactory);
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

mark nullable parameters (i.e. parameters for which a default `null` value is set) as nullable (by prefixing its type with a question mark)


#### Why?

implicitly marking a parameter as nullable will be deprecated in PHP 8.4 (see e.g. https://github.com/symfony/symfony/actions/runs/8459191951/job/23175036483?pr=54426#step:8:2951)


#### Example Usage

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do
