### PR TITLE
Forward factories implemented by PSR-18 clients if any

### DIFF
--- a/src/Psr18Client.php
+++ b/src/Psr18Client.php
@@ -33,6 +33,13 @@ class Psr18Client extends Psr17Factory implements ClientInterface
         ?UploadedFileFactoryInterface $uploadedFileFactory = null,
         ?UriFactoryInterface $uriFactory = null
     ) {
+        $requestFactory ?? $requestFactory = $client instanceof RequestFactoryInterface ? $client : null;
+        $responseFactory ?? $responseFactory = $client instanceof ResponseFactoryInterface ? $client : null;
+        $serverRequestFactory ?? $serverRequestFactory = $client instanceof ServerRequestFactoryInterface ? $client : null;
+        $streamFactory ?? $streamFactory = $client instanceof StreamFactoryInterface ? $client : null;
+        $uploadedFileFactory ?? $uploadedFileFactory = $client instanceof UploadedFileFactoryInterface ? $client : null;
+        $uriFactory ?? $uriFactory = $client instanceof UriFactoryInterface ? $client : null;
+
         parent::__construct($requestFactory, $responseFactory, $serverRequestFactory, $streamFactory, $uploadedFileFactory, $uriFactory);
 
         $this->client = $client ?? Psr18ClientDiscovery::find();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT

E.g. Symfony's PSR-18 client implements the relevant PSR-17 factories.
This is just a minor improvement.