### PR TITLE
Fix support for lock:false in Composer

### DIFF
--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -452,12 +452,21 @@ EOPHP
 
     private function updateComposerLock(Composer $composer, IOInterface $io)
     {
+        if ($composer->getConfig()->get('lock') === false) {
+            return;
+        }
+
         $lock = substr(Factory::getComposerFile(), 0, -4).'lock';
         $composerJson = file_get_contents(Factory::getComposerFile());
         $lockFile = new JsonFile($lock, null, $io);
         $locker = ClassDiscovery::safeClassExists(RepositorySet::class)
             ? new Locker($io, $lockFile, $composer->getInstallationManager(), $composerJson)
             : new Locker($io, $lockFile, $composer->getRepositoryManager(), $composer->getInstallationManager(), $composerJson);
+
+        if (!$locker->isLocked()) {
+            return;
+        }
+
         $lockData = $locker->getLockData();
         $lockData['content-hash'] = Locker::getContentHash($composerJson);
         $lockFile->write($lockData);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/composer/composer/issues/12135
| Documentation   | 
| License         | MIT


#### What's in this PR?

When composer has no lock file, it should not try to be updated


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)

